### PR TITLE
feat: replace std HashMap with FxHashMap for perf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2369,6 +2369,7 @@ dependencies = [
  "reqwest",
  "reqwest-eventsource",
  "rust_decimal",
+ "rustc-hash 2.1.1",
  "rusty-s3",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ reqwest = { version = "0.12.15", features = [
     "native-tls",
 ], default-features = false }
 reqwest-eventsource = "0.6.0"
+rustc-hash = "2.1.1"
 rust_decimal = "1.37.1"
 rusty-s3 = "0.7.0"
 semver = "1.0.26"

--- a/llm-proxy/Cargo.toml
+++ b/llm-proxy/Cargo.toml
@@ -41,6 +41,7 @@ pin-project-lite = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
 reqwest-eventsource = { workspace = true }
+rustc-hash = { workspace = true }
 rust_decimal = { workspace = true }
 rusty-s3 = { workspace = true }
 semver = { workspace = true }

--- a/llm-proxy/src/discover/monitor/health/metrics.rs
+++ b/llm-proxy/src/discover/monitor/health/metrics.rs
@@ -1,4 +1,6 @@
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
+
+use rustc_hash::FxHashMap as HashMap;
 
 use crate::{
     endpoints::{
@@ -33,7 +35,7 @@ impl EndpointMetricsRegistry {
 
 impl Default for EndpointMetricsRegistry {
     fn default() -> Self {
-        let mut inner = HashMap::new();
+        let mut inner = HashMap::default();
         inner.insert(
             ApiEndpoint::OpenAI(OpenAI::ChatCompletions(ChatCompletions)),
             EndpointMetrics::default(),

--- a/llm-proxy/src/discover/monitor/health/provider.rs
+++ b/llm-proxy/src/discover/monitor/health/provider.rs
@@ -1,13 +1,10 @@
 //! Dynamically remove inference providers that fail health checks
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-    time::Duration,
-};
+use std::{sync::Arc, time::Duration};
 
 use futures::future::{self, BoxFuture};
 use meltdown::Token;
 use rust_decimal::prelude::ToPrimitive;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use tokio::{
     sync::{RwLock, mpsc::Sender},
     time,
@@ -183,7 +180,7 @@ impl<K> ProviderMonitorInner<K> {
             tx,
             router_config,
             app_state,
-            unhealthy_keys: HashSet::new(),
+            unhealthy_keys: HashSet::default(),
         }
     }
 

--- a/llm-proxy/src/discover/monitor/rate_limit/mod.rs
+++ b/llm-proxy/src/discover/monitor/rate_limit/mod.rs
@@ -1,8 +1,9 @@
 #![allow(dead_code)]
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 use futures::future::BoxFuture;
 use meltdown::Token;
+use rustc_hash::FxHashMap as HashMap;
 use tokio::sync::{RwLock, mpsc::Sender};
 use tower::discover::Change;
 use tracing::info;

--- a/llm-proxy/src/middleware/mapper/registry.rs
+++ b/llm-proxy/src/middleware/mapper/registry.rs
@@ -1,4 +1,6 @@
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
+
+use rustc_hash::FxHashMap as HashMap;
 
 use super::{
     EndpointConverter, NoOpConverter, TypedEndpointConverter,
@@ -84,7 +86,7 @@ impl EndpointConverterRegistryInner {
     #[allow(clippy::too_many_lines)]
     fn new(router_config: &RouterConfig, model_mapper: ModelMapper) -> Self {
         let mut registry = Self {
-            converters: HashMap::new(),
+            converters: HashMap::default(),
         };
         let providers = router_config.balance.providers();
         let request_style = router_config.request_style;

--- a/llm-proxy/src/router/meta.rs
+++ b/llm-proxy/src/router/meta.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashMap,
     future::{Ready, ready},
     task::{Context, Poll},
 };
@@ -8,6 +7,7 @@ use axum_core::response::IntoResponse;
 use futures::future::Either;
 use http::uri::PathAndQuery;
 use regex::Regex;
+use rustc_hash::FxHashMap as HashMap;
 use uuid::Uuid;
 
 use super::Router;
@@ -61,8 +61,7 @@ impl MetaRouter {
     pub async fn from_config(app_state: AppState) -> Result<Self, InitError> {
         let router_id_regex =
             Regex::new(ROUTER_ID_REGEX).expect("always valid if tests pass");
-        let mut inner =
-            HashMap::with_capacity(app_state.0.config.routers.as_ref().len());
+        let mut inner = HashMap::default();
         for router_id in app_state.0.config.routers.as_ref().keys() {
             let router = Router::new(*router_id, app_state.clone()).await?;
             inner.insert(*router_id, router);

--- a/llm-proxy/src/router/mod.rs
+++ b/llm-proxy/src/router/mod.rs
@@ -1,7 +1,6 @@
 pub mod meta;
 
 use std::{
-    collections::HashMap,
     future::{Ready, ready},
     sync::Arc,
     task::{Context, Poll},
@@ -9,6 +8,7 @@ use std::{
 
 use futures::future::Either;
 use http::uri::PathAndQuery;
+use rustc_hash::FxHashMap as HashMap;
 use tower::ServiceBuilder;
 
 use crate::{
@@ -69,7 +69,7 @@ impl Router {
         };
         router_config.validate()?;
 
-        let mut inner = HashMap::new();
+        let mut inner = HashMap::default();
         for (endpoint_type, balance_config) in router_config.balance.as_ref() {
             let balancer = ProviderBalancer::new(
                 app_state.clone(),


### PR DESCRIPTION
- Add rustc-hash 2.1.1 dependency to workspace and llm-proxy

FxHashMap provides better performance for non-cryptographic use cases compared to std HashMap's SipHash, which prioritizes security against HashDoS attacks over speed.