### PR TITLE
feat(metrics): Add otel http metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
+checksum = "1237c0ae75a0f3765f58910ff9cdd0a12eeb39ab2f4c7de23262f337f0aacbb3"
 dependencies = [
  "async-lock",
  "cfg-if",
@@ -220,7 +220,7 @@ dependencies = [
  "futures-lite 2.6.0",
  "parking",
  "polling",
- "rustix 0.38.44",
+ "rustix 1.0.7",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -883,9 +883,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1557,9 +1557,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
 
 [[package]]
 name = "hex"
@@ -2268,6 +2268,7 @@ dependencies = [
  "tokio-util",
  "tower 0.5.2",
  "tower-http",
+ "tower-otel-http-metrics",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -2382,13 +2383,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2886,15 +2887,15 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polling"
-version = "3.7.4"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
+checksum = "b53a684391ad002dd6a596ceb6c74fd004fdce75f4be2e3f615068abbea5fd50"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 0.38.44",
+ "rustix 1.0.7",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -3790,7 +3791,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
  "bitflags",
- "core-foundation 0.10.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4050,9 +4051,9 @@ checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -4410,9 +4411,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.0"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4635,6 +4636,20 @@ name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-otel-http-metrics"
+version = "0.14.0"
+source = "git+https://github.com/tomharmon/tower-otel-http-metrics.git?branch=feat%2Fcustom-attributes-via-extractors#a76369886da060f8e4fc67fcf86dc471fbe1f50d"
+dependencies = [
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "opentelemetry",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "tower-service"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,8 @@ tokio-test = "0.4.4"
 tokio-util = "0.7.15"
 tower = "0.5.2"
 tower-http = { version = "0.6.3" }
+# @tom: submit upstream PR
+tower-otel-http-metrics = { git = "https://github.com/tomharmon/tower-otel-http-metrics.git", branch = "feat/custom-attributes-via-extractors" }
 tracing = "0.1.41"
 tracing-opentelemetry = "0.30.0"
 tracing-subscriber = "0.3.19"

--- a/llm-proxy/Cargo.toml
+++ b/llm-proxy/Cargo.toml
@@ -63,6 +63,7 @@ tokio-stream = { workspace = true, features = ['sync'] }
 tokio-util = { workspace = true }
 tower = { workspace = true, features = ['full']}
 tower-http = { workspace = true, features = ['default', 'auth', 'catch-panic', 'add-extension', 'normalize-path', 'request-id', 'trace', 'util', 'sensitive-headers'] }
+tower-otel-http-metrics = { workspace = true }
 tracing = { workspace = true }
 tracing-opentelemetry.workspace = true
 tracing-subscriber = { workspace = true, features = ['env-filter', 'std'] }

--- a/llm-proxy/src/discover/monitor/health/provider.rs
+++ b/llm-proxy/src/discover/monitor/health/provider.rs
@@ -264,6 +264,7 @@ impl<K> ProviderMonitorInner<K> {
 
         Dispatcher::new(
             self.app_state.clone(),
+            self.router_id,
             &self.router_config,
             provider,
             &api_key,

--- a/llm-proxy/src/discover/provider/config.rs
+++ b/llm-proxy/src/discover/provider/config.rs
@@ -74,6 +74,7 @@ impl ConfigDiscovery<Key> {
                     .clone();
                 let dispatcher = Dispatcher::new(
                     app_state.clone(),
+                    router_id,
                     router_config,
                     key.provider,
                     &api_key,
@@ -129,6 +130,7 @@ impl ConfigDiscovery<WeightedKey> {
                     .clone();
                 let dispatcher = Dispatcher::new(
                     app_state.clone(),
+                    router_id,
                     router_config,
                     key.provider,
                     &api_key,

--- a/llm-proxy/src/dispatcher/extensions.rs
+++ b/llm-proxy/src/dispatcher/extensions.rs
@@ -1,0 +1,25 @@
+use http::Extensions;
+use typed_builder::TypedBuilder;
+
+use crate::types::{
+    provider::InferenceProvider, request::AuthContext, router::RouterId,
+};
+
+#[derive(Debug, TypedBuilder)]
+pub struct ExtensionsCopier {
+    inference_provider: InferenceProvider,
+    router_id: RouterId,
+    auth_context: Option<AuthContext>,
+}
+
+impl ExtensionsCopier {
+    /// Copies required request extensions to response extensions.
+    pub fn copy_extensions(self, resp_extensions: &mut Extensions) {
+        // MapperContext, ApiEndpoint, and PathAndQuery are copied out of bound
+        // from this helper because we already removed them from the request
+        // extensions in order to use them in the dispatcher service logic.
+        resp_extensions.insert(self.inference_provider);
+        resp_extensions.insert(self.router_id);
+        resp_extensions.insert(self.auth_context);
+    }
+}

--- a/llm-proxy/src/dispatcher/mod.rs
+++ b/llm-proxy/src/dispatcher/mod.rs
@@ -8,6 +8,7 @@ use tracing::{Instrument, info_span};
 use crate::error::internal::InternalError;
 
 pub mod anthropic_client;
+mod extensions;
 pub mod openai_client;
 pub mod service;
 

--- a/llm-proxy/src/endpoints/anthropic/messages.rs
+++ b/llm-proxy/src/endpoints/anthropic/messages.rs
@@ -1,8 +1,14 @@
+use std::str::FromStr;
+
 use anthropic_ai_sdk::types::message::{
     self, CreateMessageParams, CreateMessageResponse,
 };
 
-use crate::endpoints::{Endpoint, StreamRequest};
+use crate::{
+    endpoints::{AiRequest, Endpoint},
+    middleware::mapper::error::MapperError,
+    types::model::Model,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct Messages;
@@ -14,8 +20,12 @@ impl Endpoint for Messages {
     type StreamResponseBody = message::StreamEvent;
 }
 
-impl StreamRequest for CreateMessageParams {
+impl AiRequest for CreateMessageParams {
     fn is_stream(&self) -> bool {
         self.stream.unwrap_or(false)
+    }
+
+    fn model(&self) -> Result<Model, MapperError> {
+        Model::from_str(&self.model)
     }
 }

--- a/llm-proxy/src/endpoints/mod.rs
+++ b/llm-proxy/src/endpoints/mod.rs
@@ -7,7 +7,8 @@ use serde::{Deserialize, Serialize};
 use crate::{
     endpoints::{anthropic::Anthropic, openai::OpenAI},
     error::invalid_req::InvalidRequestError,
-    types::provider::InferenceProvider,
+    middleware::mapper::error::MapperError,
+    types::{model::Model, provider::InferenceProvider},
 };
 
 pub trait Endpoint {
@@ -19,8 +20,9 @@ pub trait Endpoint {
     type StreamResponseBody;
 }
 
-pub trait StreamRequest {
+pub trait AiRequest {
     fn is_stream(&self) -> bool;
+    fn model(&self) -> Result<Model, MapperError>;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/llm-proxy/src/endpoints/openai/chat_completions.rs
+++ b/llm-proxy/src/endpoints/openai/chat_completions.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use async_openai::types::{
     ChatCompletionRequestDeveloperMessageContent, ChatCompletionRequestMessage,
     ChatCompletionRequestSystemMessageContent,
@@ -5,7 +7,11 @@ use async_openai::types::{
     CreateChatCompletionResponse, CreateChatCompletionStreamResponse,
 };
 
-use crate::endpoints::{Endpoint, StreamRequest};
+use crate::{
+    endpoints::{AiRequest, Endpoint},
+    middleware::mapper::error::MapperError,
+    types::model::Model,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct ChatCompletions;
@@ -17,9 +23,13 @@ impl Endpoint for ChatCompletions {
     type StreamResponseBody = CreateChatCompletionStreamResponse;
 }
 
-impl StreamRequest for CreateChatCompletionRequest {
+impl AiRequest for CreateChatCompletionRequest {
     fn is_stream(&self) -> bool {
         self.stream.unwrap_or(false)
+    }
+
+    fn model(&self) -> Result<Model, MapperError> {
+        Model::from_str(&self.model)
     }
 }
 

--- a/llm-proxy/src/error/init.rs
+++ b/llm-proxy/src/error/init.rs
@@ -37,4 +37,6 @@ pub enum InitError {
     CreateRedisPool(#[from] r2d2::Error),
     /// Failed to create redis client: {0}
     CreateRedisClient(#[from] redis::RedisError),
+    /// Failed to build otel metrics layer: {0}
+    InitOtelMetricsLayer(#[from] tower_otel_http_metrics::Error),
 }

--- a/llm-proxy/src/metrics/attribute_extractor.rs
+++ b/llm-proxy/src/metrics/attribute_extractor.rs
@@ -1,0 +1,37 @@
+use http::uri::PathAndQuery;
+use opentelemetry::KeyValue;
+use tower_otel_http_metrics::ResponseAttributeExtractor;
+
+use crate::types::{
+    provider::InferenceProvider, request::MapperContext, router::RouterId,
+};
+
+#[derive(Debug, Clone)]
+pub struct AttributeExtractor;
+
+impl<B> ResponseAttributeExtractor<B> for AttributeExtractor {
+    fn extract_attributes(
+        &self,
+        response: &http::Response<B>,
+    ) -> Vec<KeyValue> {
+        let resp_extensions = response.extensions();
+        let mut attributes = Vec::new();
+        if let Some(mapper_ctx) = resp_extensions.get::<MapperContext>() {
+            attributes.push(KeyValue::new("stream", mapper_ctx.is_stream));
+            if let Some(model) = &mapper_ctx.model {
+                attributes.push(KeyValue::new("model", model.to_string()));
+            }
+        }
+        if let Some(path) = resp_extensions.get::<PathAndQuery>() {
+            attributes
+                .push(KeyValue::new("provider_path", path.path().to_string()));
+        }
+        if let Some(provider) = resp_extensions.get::<InferenceProvider>() {
+            attributes.push(KeyValue::new("provider", provider.to_string()));
+        }
+        if let Some(router_id) = resp_extensions.get::<RouterId>() {
+            attributes.push(KeyValue::new("router_id", router_id.to_string()));
+        }
+        attributes
+    }
+}

--- a/llm-proxy/src/metrics/mod.rs
+++ b/llm-proxy/src/metrics/mod.rs
@@ -1,0 +1,24 @@
+pub mod attribute_extractor;
+pub mod rolling_counter;
+
+use opentelemetry::metrics::{Counter, Meter};
+
+pub use self::rolling_counter::RollingCounter;
+
+/// The top level struct that contains all metrics
+/// which are exported to OpenTelemetry.
+#[derive(Debug, Clone)]
+pub struct Metrics {
+    pub error_count: Counter<u64>,
+}
+
+impl Metrics {
+    #[must_use]
+    pub fn new(meter: &Meter) -> Self {
+        let error_count = meter
+            .u64_counter("error_count")
+            .with_description("Number of error occurences")
+            .build();
+        Self { error_count }
+    }
+}

--- a/llm-proxy/src/metrics/rolling_counter.rs
+++ b/llm-proxy/src/metrics/rolling_counter.rs
@@ -3,26 +3,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use opentelemetry::metrics::{Counter, Meter};
-
-/// The top level struct that contains all metrics
-/// which are exported to OpenTelemetry.
-#[derive(Debug, Clone)]
-pub struct Metrics {
-    pub error_count: Counter<u64>,
-}
-
-impl Metrics {
-    #[must_use]
-    pub fn new(meter: &Meter) -> Self {
-        let error_count = meter
-            .u64_counter("error_count")
-            .with_description("Number of error occurences")
-            .build();
-        Self { error_count }
-    }
-}
-
 #[derive(Debug)]
 pub struct RollingCounter {
     /// How many buckets to use

--- a/llm-proxy/src/middleware/add_extension.rs
+++ b/llm-proxy/src/middleware/add_extension.rs
@@ -1,0 +1,64 @@
+use std::task::{Context, Poll};
+
+use http::{Request, Response};
+use tower::{Layer, Service};
+use typed_builder::TypedBuilder;
+
+use super::mapper::registry::EndpointConverterRegistry;
+use crate::types::{provider::InferenceProvider, router::RouterId};
+
+/// [`Layer`] to add all required request extensions.
+#[derive(Clone, Debug, TypedBuilder)]
+pub struct AddExtensionsLayer {
+    endpoint_converter_registry: EndpointConverterRegistry,
+    inference_provider: InferenceProvider,
+    router_id: RouterId,
+}
+
+impl<S> Layer<S> for AddExtensionsLayer {
+    type Service = AddExtensions<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        AddExtensions {
+            inner,
+            endpoint_converter_registry: self
+                .endpoint_converter_registry
+                .clone(),
+            inference_provider: self.inference_provider,
+            router_id: self.router_id,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct AddExtensions<S> {
+    inner: S,
+    endpoint_converter_registry: EndpointConverterRegistry,
+    inference_provider: InferenceProvider,
+    router_id: RouterId,
+}
+
+impl<ResBody, ReqBody, S> Service<Request<ReqBody>> for AddExtensions<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    #[inline]
+    fn poll_ready(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
+        req.extensions_mut()
+            .insert(self.endpoint_converter_registry.clone());
+        req.extensions_mut().insert(self.inference_provider);
+        req.extensions_mut().insert(self.router_id);
+        self.inner.call(req)
+    }
+}

--- a/llm-proxy/src/middleware/mod.rs
+++ b/llm-proxy/src/middleware/mod.rs
@@ -1,3 +1,4 @@
+pub mod add_extension;
 pub mod auth;
 pub mod mapper;
 pub mod rate_limit;

--- a/llm-proxy/src/router/service.rs
+++ b/llm-proxy/src/router/service.rs
@@ -89,6 +89,7 @@ impl Router {
             })?;
         let direct_proxy_dispatcher = Dispatcher::new(
             app_state,
+            id,
             &router_config,
             router_config.request_style,
             direct_proxy_provider_api_key,

--- a/llm-proxy/src/types/request.rs
+++ b/llm-proxy/src/types/request.rs
@@ -35,9 +35,13 @@ pub struct RequestContext {
     pub country_code: CountryCode,
 }
 
-#[derive(Debug, Clone, Copy)]
-pub struct StreamContext {
+#[derive(Debug, Clone)]
+pub struct MapperContext {
     pub is_stream: bool,
+    /// If `None`, the request was for an endpoint without
+    /// first class support for mapping between different provider
+    /// models.
+    pub model: Option<Model>,
 }
 
 #[derive(Debug)]

--- a/scripts/test/src/main.rs
+++ b/scripts/test/src/main.rs
@@ -1,7 +1,7 @@
 use futures::StreamExt;
 
 pub async fn test() {
-    let is_stream = true;
+    let is_stream = false;
     let openai_request_body = serde_json::json!({
         "model": "gpt-4o-mini",
         "messages": [


### PR DESCRIPTION
- Adds standard Opentelemetry http server metrics via the `tower-otel-http-metrics` crate.
- Uses new `Extractor` feature of `tower-otel-http-metrics` to provide custom attributes to our metrics (eg provider, model, etc). This lets us filter our metrics down via these attributes, giving better granularity and insight into the router and upstream provders.
- Extractors work via request+response extensions, so adds an `ExtensionCopier` type to aid in easily copying request expensions to the response extensions so they can be extracted and added as the metric attribute downstream in the request processing lifecycle