### PR TITLE
feat(metrics): better error metrics

### DIFF
--- a/llm-proxy/src/error/api.rs
+++ b/llm-proxy/src/error/api.rs
@@ -5,18 +5,23 @@ use serde::Serialize;
 use thiserror::Error;
 use utoipa::ToSchema;
 
-use super::invalid_req::InvalidRequestError;
+use super::{
+    ErrorMetric,
+    auth::{AuthError, AuthErrorMetric},
+    internal::{InternalError, InternalErrorMetric},
+    invalid_req::{InvalidRequestError, InvalidRequestErrorMetric},
+};
 use crate::types::json::Json;
 
 /// Common API errors
 #[derive(Debug, Error, Display, strum::AsRefStr)]
-pub enum Error {
+pub enum ApiError {
     /// Invalid request: {0}
     InvalidRequest(#[from] InvalidRequestError),
     /// Authentication error: {0}
-    Authentication(#[from] crate::error::auth::AuthError),
+    Authentication(#[from] AuthError),
     /// Internal error: {0}
-    Internal(#[from] crate::error::internal::InternalError),
+    Internal(#[from] InternalError),
     /// Box: {0}
     Box(#[from] Box<dyn std::error::Error + Send + Sync>),
 }
@@ -29,13 +34,13 @@ pub struct ErrorResponse {
     pub error: String,
 }
 
-impl IntoResponse for Error {
+impl IntoResponse for ApiError {
     fn into_response(self) -> axum_core::response::Response {
         match self {
-            Error::InvalidRequest(error) => error.into_response(),
-            Error::Authentication(error) => error.into_response(),
-            Error::Internal(error) => error.into_response(),
-            Error::Box(error) => {
+            ApiError::InvalidRequest(error) => error.into_response(),
+            ApiError::Authentication(error) => error.into_response(),
+            ApiError::Internal(error) => error.into_response(),
+            ApiError::Box(error) => {
                 tracing::error!(error = %error, "Internal server error");
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
@@ -46,5 +51,65 @@ impl IntoResponse for Error {
                     .into_response()
             }
         }
+    }
+}
+
+/// Top level metric type that reduces cardinality such that
+/// we can use the error type in metrics.
+#[derive(Debug, Error, Display, strum::AsRefStr)]
+pub enum ApiErrorMetric {
+    /// Invalid request
+    InvalidRequest(#[from] InvalidRequestErrorMetric),
+    /// Authentication
+    Authentication(#[from] AuthErrorMetric),
+    /// Internal
+    Internal(#[from] InternalErrorMetric),
+    /// Boxed error
+    Box,
+}
+
+impl From<&ApiError> for ApiErrorMetric {
+    fn from(error: &ApiError) -> Self {
+        match error {
+            ApiError::InvalidRequest(invalid_request_error) => {
+                Self::InvalidRequest(InvalidRequestErrorMetric::from(
+                    invalid_request_error,
+                ))
+            }
+            ApiError::Authentication(auth_error) => {
+                Self::Authentication(AuthErrorMetric::from(auth_error))
+            }
+            ApiError::Internal(internal_error) => {
+                Self::Internal(InternalErrorMetric::from(internal_error))
+            }
+            ApiError::Box(_error) => Self::Box,
+        }
+    }
+}
+
+impl ErrorMetric for ApiErrorMetric {
+    fn error_metric(&self) -> String {
+        match self {
+            Self::InvalidRequest(error) => {
+                format!("InvalidRequest:{}", error.as_ref())
+            }
+            Self::Authentication(error) => {
+                format!("Authentication:{}", error.as_ref())
+            }
+            Self::Internal(error) => {
+                if let InternalErrorMetric::MapperError(e) = error {
+                    format!("InternalError:MapperError:{}", e.as_ref())
+                } else {
+                    format!("InternalError:{}", error.as_ref())
+                }
+            }
+            Self::Box => String::from("Box"),
+        }
+    }
+}
+
+impl ErrorMetric for ApiError {
+    fn error_metric(&self) -> String {
+        ApiErrorMetric::from(self).error_metric()
     }
 }

--- a/llm-proxy/src/error/auth.rs
+++ b/llm-proxy/src/error/auth.rs
@@ -1,15 +1,18 @@
 use axum_core::response::{IntoResponse, Response};
 use displaydoc::Display;
 use http::StatusCode;
+use thiserror::Error;
 use tracing::error;
 
 use super::api::ErrorResponse;
 use crate::types::json::Json;
 
-#[derive(Debug, strum::AsRefStr, thiserror::Error, Display)]
+#[derive(Debug, strum::AsRefStr, Error, Display)]
 pub enum AuthError {
-    /// Reqwest error: {0}
-    Reqwest(#[from] reqwest::Error),
+    /// Reqwest transport error: {0}
+    Transport(#[from] reqwest::Error),
+    /// Unsuccessful auth response: {0}
+    UnsuccessfulAuthResponse(reqwest::Error),
     /// Missing authorization header
     MissingAuthorizationHeader,
     /// Invalid credentials
@@ -19,8 +22,8 @@ pub enum AuthError {
 impl IntoResponse for AuthError {
     fn into_response(self) -> Response {
         match self {
-            Self::Reqwest(error) => {
-                error!(error = %error, "reqwest error");
+            Self::Transport(error) => {
+                error!(error = %error, "reqwest transport error");
                 (
                     error.status().unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
                     Json(ErrorResponse {
@@ -29,6 +32,13 @@ impl IntoResponse for AuthError {
                 )
                     .into_response()
             }
+            Self::UnsuccessfulAuthResponse(error) => (
+                error.status().unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+                Json(ErrorResponse {
+                    error: "Authentication error".to_string(),
+                }),
+            )
+                .into_response(),
             Self::MissingAuthorizationHeader => (
                 StatusCode::UNAUTHORIZED,
                 Json(ErrorResponse {
@@ -43,6 +53,36 @@ impl IntoResponse for AuthError {
                 }),
             )
                 .into_response(),
+        }
+    }
+}
+
+/// Auth errors for metrics. This is a special type
+/// that avoids including dynamic information to limit cardinality
+/// such that we can use this type in metrics.
+#[derive(Debug, Error, Display, strum::AsRefStr)]
+pub enum AuthErrorMetric {
+    /// Reqwest transport error
+    Transport,
+    /// Unsuccessful auth response
+    UnsuccessfulAuthResponse,
+    /// Missing authorization header
+    MissingAuthorizationHeader,
+    /// Invalid credentials
+    InvalidCredentials,
+}
+
+impl From<&AuthError> for AuthErrorMetric {
+    fn from(error: &AuthError) -> Self {
+        match error {
+            AuthError::Transport(_) => Self::Transport,
+            AuthError::UnsuccessfulAuthResponse(_) => {
+                Self::UnsuccessfulAuthResponse
+            }
+            AuthError::MissingAuthorizationHeader => {
+                Self::MissingAuthorizationHeader
+            }
+            AuthError::InvalidCredentials => Self::InvalidCredentials,
         }
     }
 }

--- a/llm-proxy/src/error/invalid_req.rs
+++ b/llm-proxy/src/error/invalid_req.rs
@@ -86,3 +86,41 @@ impl IntoResponse for InvalidRequestError {
         }
     }
 }
+
+/// User errors for metrics. This is a special type
+/// that avoids including dynamic information to limit cardinality
+/// such that we can use this type in metrics.
+#[derive(Debug, Error, Display, strum::AsRefStr)]
+pub enum InvalidRequestErrorMetric {
+    /// Resource not found
+    NotFound,
+    /// Unsupported provider
+    UnsupportedProvider,
+    /// Invalid request
+    InvalidRequest,
+    /// Invalid request uri
+    InvalidUri,
+    /// Invalid request body
+    InvalidRequestBody,
+    /// Upstream 4xx error
+    Provider4xxError,
+}
+
+impl From<&InvalidRequestError> for InvalidRequestErrorMetric {
+    fn from(error: &InvalidRequestError) -> Self {
+        match error {
+            InvalidRequestError::UnsupportedProvider(_) => {
+                Self::UnsupportedProvider
+            }
+            InvalidRequestError::NotFound(_)
+            | InvalidRequestError::RouterIdNotFound(_)
+            | InvalidRequestError::MissingRouterId => Self::NotFound,
+            InvalidRequestError::InvalidRequest(_) => Self::InvalidRequest,
+            InvalidRequestError::InvalidUri(_) => Self::InvalidUri,
+            InvalidRequestError::InvalidRequestBody(_) => {
+                Self::InvalidRequestBody
+            }
+            InvalidRequestError::Provider4xxError(_) => Self::Provider4xxError,
+        }
+    }
+}

--- a/llm-proxy/src/error/mod.rs
+++ b/llm-proxy/src/error/mod.rs
@@ -6,3 +6,9 @@ pub mod invalid_req;
 pub mod logger;
 pub mod provider;
 pub mod runtime;
+
+pub trait ErrorMetric {
+    /// Convert an error type into a low-cardinality string
+    /// that can be used in metrics.
+    fn error_metric(&self) -> String;
+}

--- a/llm-proxy/src/middleware/auth.rs
+++ b/llm-proxy/src/middleware/auth.rs
@@ -35,7 +35,8 @@ impl AuthService {
             .header("authorization", api_key)
             .send()
             .await?
-            .error_for_status()?;
+            .error_for_status()
+            .map_err(AuthError::UnsuccessfulAuthResponse)?;
         let body = whoami_result.json::<WhoamiResponse>().await?;
         Ok(AuthContext {
             api_key: api_key.replace("Bearer ", ""),

--- a/llm-proxy/src/middleware/mapper/error.rs
+++ b/llm-proxy/src/middleware/mapper/error.rs
@@ -1,10 +1,11 @@
 use displaydoc::Display;
+use strum::AsRefStr;
 use thiserror::Error;
 
 use crate::types::provider::InferenceProvider;
 
 /// Error types that can occur when mapping requests between providers.
-#[derive(Debug, Error, Display)]
+#[derive(Debug, Error, Display, AsRefStr)]
 pub enum MapperError {
     /// Failed to convert chat completion request
     ChatConversion,
@@ -24,4 +25,43 @@ pub enum MapperError {
     StreamError(String),
     /// Empty response body
     EmptyResponseBody,
+}
+
+/// Error types that can occur when mapping requests between providers.
+#[derive(Debug, Error, Display, strum::AsRefStr)]
+pub enum MapperErrorMetric {
+    /// Failed to convert chat completion request
+    ChatConversion,
+    /// No model mapping found
+    NoModelMapping,
+    /// Invalid model name
+    InvalidModelName,
+    /// No global provider config found
+    NoProviderConfig,
+    /// Provider not enabled in router config
+    ProviderNotEnabled,
+    /// Invalid request body
+    InvalidRequest,
+    /// Serde error
+    SerdeError,
+    /// Underlying stream error
+    StreamError,
+    /// Empty response body
+    EmptyResponseBody,
+}
+
+impl From<&MapperError> for MapperErrorMetric {
+    fn from(error: &MapperError) -> Self {
+        match error {
+            MapperError::ChatConversion => Self::ChatConversion,
+            MapperError::NoModelMapping(_, _) => Self::NoModelMapping,
+            MapperError::InvalidModelName(_) => Self::InvalidModelName,
+            MapperError::NoProviderConfig(_) => Self::NoProviderConfig,
+            MapperError::ProviderNotEnabled(_) => Self::ProviderNotEnabled,
+            MapperError::InvalidRequest => Self::InvalidRequest,
+            MapperError::SerdeError(_) => Self::SerdeError,
+            MapperError::StreamError(_) => Self::StreamError,
+            MapperError::EmptyResponseBody => Self::EmptyResponseBody,
+        }
+    }
 }

--- a/llm-proxy/src/middleware/mapper/mod.rs
+++ b/llm-proxy/src/middleware/mapper/mod.rs
@@ -37,7 +37,8 @@ pub use self::service::*;
 use crate::{
     endpoints::{AiRequest, Endpoint},
     error::{
-        api::Error, internal::InternalError, invalid_req::InvalidRequestError,
+        api::ApiError, internal::InternalError,
+        invalid_req::InvalidRequestError,
     },
     types::request::MapperContext,
 };
@@ -72,7 +73,7 @@ pub trait EndpointConverter {
     fn convert_req_body(
         &self,
         req_body_bytes: Bytes,
-    ) -> Result<(Bytes, MapperContext), Error>;
+    ) -> Result<(Bytes, MapperContext), ApiError>;
     /// Convert a response body to a target response body with raw bytes.
     ///
     /// Returns `None` if there is no applicable mapping for a given chunk
@@ -81,7 +82,7 @@ pub trait EndpointConverter {
         &self,
         resp_body_bytes: Bytes,
         is_stream: bool,
-    ) -> Result<Option<Bytes>, Error>;
+    ) -> Result<Option<Bytes>, ApiError>;
 }
 
 pub struct TypedEndpointConverter<S, T, C>
@@ -131,7 +132,7 @@ where
     fn convert_req_body(
         &self,
         bytes: Bytes,
-    ) -> Result<(Bytes, MapperContext), Error> {
+    ) -> Result<(Bytes, MapperContext), ApiError> {
         let source_request: S::RequestBody = serde_json::from_slice(&bytes)
             .map_err(InvalidRequestError::InvalidRequestBody)?;
         let is_stream = source_request.is_stream();
@@ -152,7 +153,7 @@ where
         Ok((target_bytes, mapper_ctx))
     }
 
-    fn convert_resp_body(&self, bytes: Bytes, is_stream: bool) -> Result<Option<Bytes>, Error> {
+    fn convert_resp_body(&self, bytes: Bytes, is_stream: bool) -> Result<Option<Bytes>, ApiError> {
         if is_stream {
             let source_response: T::StreamResponseBody =
                 serde_json::from_slice(&bytes)
@@ -236,7 +237,7 @@ where
     fn convert_req_body(
         &self,
         bytes: Bytes,
-    ) -> Result<(Bytes, MapperContext), Error> {
+    ) -> Result<(Bytes, MapperContext), ApiError> {
         let source_request: S::RequestBody = serde_json::from_slice(&bytes)
             .map_err(InvalidRequestError::InvalidRequestBody)?;
         let is_stream = source_request.is_stream();
@@ -253,7 +254,7 @@ where
         &self,
         bytes: Bytes,
         _is_stream: bool,
-    ) -> Result<Option<Bytes>, Error> {
+    ) -> Result<Option<Bytes>, ApiError> {
         Ok(Some(bytes))
     }
 }

--- a/llm-proxy/src/router/service.rs
+++ b/llm-proxy/src/router/service.rs
@@ -16,7 +16,7 @@ use crate::{
     dispatcher::{Dispatcher, DispatcherService},
     endpoints::{ApiEndpoint, EndpointType},
     error::{
-        api::Error, init::InitError, internal::InternalError,
+        api::ApiError, init::InitError, internal::InternalError,
         invalid_req::InvalidRequestError, provider::ProviderError,
     },
     middleware::request_context,
@@ -132,7 +132,7 @@ impl Router {
 
 impl tower::Service<crate::types::request::Request> for Router {
     type Response = crate::types::response::Response;
-    type Error = Error;
+    type Error = ApiError;
     type Future = RouterFuture;
 
     #[inline]
@@ -194,7 +194,7 @@ impl tower::Service<crate::types::request::Request> for Router {
 
 pub enum RouterFuture {
     /// Ready with an immediate response
-    Ready(Ready<Result<crate::types::response::Response, Error>>),
+    Ready(Ready<Result<crate::types::response::Response, ApiError>>),
     /// Calling the `ProviderBalancer`
     Balancer(<RouterService as tower::Service<crate::types::request::Request>>::Future),
     /// Calling the direct proxy
@@ -202,7 +202,7 @@ pub enum RouterFuture {
 }
 
 impl Future for RouterFuture {
-    type Output = Result<crate::types::response::Response, Error>;
+    type Output = Result<crate::types::response::Response, ApiError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.get_mut() {

--- a/llm-proxy/src/utils/mod.rs
+++ b/llm-proxy/src/utils/mod.rs
@@ -14,11 +14,11 @@ use url::Url;
 use crate::error::{internal::InternalError, invalid_req::InvalidRequestError};
 
 pub trait ResponseExt: Sized {
-    fn error_for_status(self) -> Result<Self, crate::error::api::Error>;
+    fn error_for_status(self) -> Result<Self, crate::error::api::ApiError>;
 }
 
 impl<B> ResponseExt for http::Response<B> {
-    fn error_for_status(self) -> Result<Self, crate::error::api::Error> {
+    fn error_for_status(self) -> Result<Self, crate::error::api::ApiError> {
         let status = self.status();
         if status.is_client_error() {
             Err(InvalidRequestError::Provider4xxError(status).into())


### PR DESCRIPTION
feat(metrics): Add better error metrics

Previously our error metrics only exposed three kinds (Internal, Auth,

and Invalid request) and thus wasn't super insightful.
This commit adds a new pattern: `*ErrorMetric` types that don't contain
inner dynamic data, ie, are essentially just static strings with low
cardinality. This makes it possible to put an upper bound on the
cardinality of the error types our metrics receive which is required to
not cause prometheus to slow to a crawl.

From impls are added from `&OriginalErrorType` to the `*ErrorMetric`
type to make conversion cheap and easy and is combined with a top level
`ErrorMetric` trait to get the final error string to report the error
type/kind in Opentelemetry.
