### PR TITLE
feat: Configurable response headers

### DIFF
--- a/llm-proxy/src/config/mod.rs
+++ b/llm-proxy/src/config/mod.rs
@@ -8,6 +8,7 @@ pub mod monitor;
 pub mod providers;
 pub mod rate_limit;
 pub mod redis;
+pub mod response_headers;
 pub mod retry;
 pub mod router;
 pub mod server;
@@ -89,6 +90,7 @@ pub struct Config {
     pub routers: self::router::RouterConfigs,
     pub deployment_target: DeploymentTarget,
     pub is_production: bool,
+    pub response_headers: self::response_headers::ResponseHeadersConfig,
     pub helicone: self::helicone::HeliconeConfig,
 }
 
@@ -145,6 +147,8 @@ impl crate::tests::TestDefault for Config {
             deployment_target: DeploymentTarget::SelfHosted,
             discover: self::discover::DiscoverConfig::test_default(),
             routers: self::router::RouterConfigs::test_default(),
+            response_headers:
+                self::response_headers::ResponseHeadersConfig::default(),
             rate_limit: self::rate_limit::TopLevelRateLimitConfig::test_default(
             ),
         }

--- a/llm-proxy/src/config/response_headers.rs
+++ b/llm-proxy/src/config/response_headers.rs
@@ -1,0 +1,11 @@
+use serde::{Deserialize, Serialize};
+
+/// Response headers useful for additional observability.
+#[derive(Default, Debug, Clone, Copy, Deserialize, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub struct ResponseHeadersConfig {
+    #[serde(default)]
+    pub provider: bool,
+    #[serde(default)]
+    pub provider_request_id: bool,
+}

--- a/llm-proxy/src/dispatcher/extensions.rs
+++ b/llm-proxy/src/dispatcher/extensions.rs
@@ -2,7 +2,8 @@ use http::Extensions;
 use typed_builder::TypedBuilder;
 
 use crate::types::{
-    provider::InferenceProvider, request::AuthContext, router::RouterId,
+    extensions::ProviderRequestId, provider::InferenceProvider,
+    request::AuthContext, router::RouterId,
 };
 
 #[derive(Debug, TypedBuilder)]
@@ -10,6 +11,7 @@ pub struct ExtensionsCopier {
     inference_provider: InferenceProvider,
     router_id: RouterId,
     auth_context: Option<AuthContext>,
+    provider_request_id: Option<http::HeaderValue>,
 }
 
 impl ExtensionsCopier {
@@ -21,5 +23,8 @@ impl ExtensionsCopier {
         resp_extensions.insert(self.inference_provider);
         resp_extensions.insert(self.router_id);
         resp_extensions.insert(self.auth_context);
+        if let Some(provider_request_id) = self.provider_request_id {
+            resp_extensions.insert(ProviderRequestId(provider_request_id));
+        }
     }
 }

--- a/llm-proxy/src/dispatcher/service.rs
+++ b/llm-proxy/src/dispatcher/service.rs
@@ -229,11 +229,6 @@ impl Dispatcher {
             .get::<RouterId>()
             .copied()
             .ok_or(InternalError::ExtensionNotFound("RouterId"))?;
-        let extensions_copier = ExtensionsCopier::builder()
-            .inference_provider(inference_provider)
-            .router_id(router_id)
-            .auth_context(auth_ctx.cloned())
-            .build();
 
         let target_url = base_url
             .join(extracted_path_and_query.as_str())
@@ -291,6 +286,12 @@ impl Dispatcher {
             headers.remove("x-request-id")
         };
         tracing::debug!(provider_req_id = ?provider_request_id, status = %response.status(), "received response");
+        let extensions_copier = ExtensionsCopier::builder()
+            .inference_provider(inference_provider)
+            .router_id(router_id)
+            .auth_context(auth_ctx.cloned())
+            .provider_request_id(provider_request_id)
+            .build();
         extensions_copier.copy_extensions(response.extensions_mut());
         response.extensions_mut().insert(mapper_ctx);
         response.extensions_mut().insert(api_endpoint);

--- a/llm-proxy/src/middleware/mod.rs
+++ b/llm-proxy/src/middleware/mod.rs
@@ -3,3 +3,4 @@ pub mod auth;
 pub mod mapper;
 pub mod rate_limit;
 pub mod request_context;
+pub mod response_headers;

--- a/llm-proxy/src/middleware/response_headers.rs
+++ b/llm-proxy/src/middleware/response_headers.rs
@@ -1,0 +1,309 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::ready;
+use http::{Request, Response};
+use pin_project_lite::pin_project;
+
+use crate::{
+    config::response_headers::ResponseHeadersConfig,
+    types::{extensions::ProviderRequestId, provider::InferenceProvider},
+};
+
+#[derive(Debug, Clone)]
+pub struct ResponseHeaderService<S> {
+    config: ResponseHeadersConfig,
+    inner: S,
+}
+
+impl<S> ResponseHeaderService<S> {
+    pub const fn new(
+        config: ResponseHeadersConfig,
+        inner: S,
+    ) -> ResponseHeaderService<S> {
+        ResponseHeaderService { config, inner }
+    }
+}
+
+impl<S, ReqBody, RespBody> tower::Service<Request<ReqBody>>
+    for ResponseHeaderService<S>
+where
+    S: tower::Service<Request<ReqBody>, Response = Response<RespBody>>
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future>;
+
+    #[inline]
+    fn poll_ready(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        ResponseFuture {
+            config: self.config,
+            inner: self.inner.call(req),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ResponseHeaderLayer(ResponseHeadersConfig);
+
+impl ResponseHeaderLayer {
+    #[must_use]
+    pub const fn new(config: ResponseHeadersConfig) -> Self {
+        Self(config)
+    }
+}
+
+impl<S> tower::Layer<S> for ResponseHeaderLayer {
+    type Service = ResponseHeaderService<S>;
+
+    fn layer(&self, service: S) -> ResponseHeaderService<S> {
+        ResponseHeaderService::new(self.0, service)
+    }
+}
+
+pin_project! {
+    pub struct ResponseFuture<F> {
+        config: ResponseHeadersConfig,
+        #[pin]
+        inner: F,
+    }
+}
+
+impl<F, RespBody, E> Future for ResponseFuture<F>
+where
+    F: Future<Output = Result<Response<RespBody>, E>>,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let mut response = match ready!(this.inner.poll(cx)) {
+            Ok(response) => response,
+            Err(e) => {
+                return Poll::Ready(Err(e));
+            }
+        };
+        if this.config.provider {
+            let inference_provider =
+                response.extensions().get::<InferenceProvider>().copied();
+            if let Some(inference_provider) = inference_provider {
+                if let Ok(header_value) =
+                    http::HeaderValue::from_str(inference_provider.as_ref())
+                {
+                    response
+                        .headers_mut()
+                        .insert("helicone-provider", header_value);
+                }
+            }
+        }
+
+        if this.config.provider_request_id {
+            let provider_request_id =
+                response.extensions().get::<ProviderRequestId>().cloned();
+            if let Some(provider_request_id) = provider_request_id {
+                response
+                    .headers_mut()
+                    .insert("helicone-provider-req-id", provider_request_id.0);
+            }
+        }
+        Poll::Ready(Ok(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+
+    use http::HeaderValue;
+    use tower::{Service, ServiceExt, service_fn};
+
+    use super::*;
+
+    fn create_mock_service<F>(
+        response_fn: F,
+    ) -> impl tower::Service<
+        Request<()>,
+        Response = Response<String>,
+        Error = Infallible,
+        Future = std::future::Ready<Result<Response<String>, Infallible>>,
+    >
+    where
+        F: Fn() -> Response<String> + Clone,
+    {
+        service_fn(move |_req| {
+            let response_fn = response_fn.clone();
+            std::future::ready(Ok(response_fn()))
+        })
+    }
+
+    #[tokio::test]
+    async fn test_response_headers_disabled() {
+        let config = ResponseHeadersConfig {
+            provider: false,
+            provider_request_id: false,
+        };
+
+        let mut service = ResponseHeaderService::new(
+            config,
+            create_mock_service(|| {
+                let mut response = Response::new("test".to_string());
+                response.extensions_mut().insert(InferenceProvider::OpenAI);
+                response.extensions_mut().insert(ProviderRequestId(
+                    HeaderValue::from_static("test-req-id"),
+                ));
+                response
+            }),
+        );
+
+        let request = Request::new(());
+        let response =
+            service.ready().await.unwrap().call(request).await.unwrap();
+
+        assert!(!response.headers().contains_key("helicone-provider"));
+        assert!(!response.headers().contains_key("helicone-provider-req-id"));
+    }
+
+    #[tokio::test]
+    async fn test_provider_header_enabled() {
+        let config = ResponseHeadersConfig {
+            provider: true,
+            provider_request_id: false,
+        };
+
+        let mut service = ResponseHeaderService::new(
+            config,
+            create_mock_service(|| {
+                let mut response = Response::new("test".to_string());
+                response
+                    .extensions_mut()
+                    .insert(InferenceProvider::Anthropic);
+                response
+            }),
+        );
+
+        let request = Request::new(());
+        let response =
+            service.ready().await.unwrap().call(request).await.unwrap();
+
+        assert_eq!(
+            response.headers().get("helicone-provider").unwrap(),
+            "anthropic"
+        );
+        assert!(!response.headers().contains_key("helicone-provider-req-id"));
+    }
+
+    #[tokio::test]
+    async fn test_provider_request_id_header_enabled() {
+        let config = ResponseHeadersConfig {
+            provider: false,
+            provider_request_id: true,
+        };
+
+        let mut service = ResponseHeaderService::new(
+            config,
+            create_mock_service(|| {
+                let mut response = Response::new("test".to_string());
+                response.extensions_mut().insert(ProviderRequestId(
+                    HeaderValue::from_static("req-123"),
+                ));
+                response
+            }),
+        );
+
+        let request = Request::new(());
+        let response =
+            service.ready().await.unwrap().call(request).await.unwrap();
+
+        assert!(!response.headers().contains_key("helicone-provider"));
+        assert_eq!(
+            response.headers().get("helicone-provider-req-id").unwrap(),
+            "req-123"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_both_headers_enabled() {
+        let config = ResponseHeadersConfig {
+            provider: true,
+            provider_request_id: true,
+        };
+
+        let mut service = ResponseHeaderService::new(
+            config,
+            create_mock_service(|| {
+                let mut response = Response::new("test".to_string());
+                response
+                    .extensions_mut()
+                    .insert(InferenceProvider::GoogleGemini);
+                response.extensions_mut().insert(ProviderRequestId(
+                    HeaderValue::from_static("gemini-req-456"),
+                ));
+                response
+            }),
+        );
+
+        let request = Request::new(());
+        let response =
+            service.ready().await.unwrap().call(request).await.unwrap();
+
+        assert_eq!(
+            response.headers().get("helicone-provider").unwrap(),
+            "gemini"
+        );
+        assert_eq!(
+            response.headers().get("helicone-provider-req-id").unwrap(),
+            "gemini-req-456"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_missing_provider_extension() {
+        let config = ResponseHeadersConfig {
+            provider: true,
+            provider_request_id: false,
+        };
+
+        let mut service = ResponseHeaderService::new(
+            config,
+            create_mock_service(|| Response::new("test".to_string())),
+        );
+
+        let request = Request::new(());
+        let response =
+            service.ready().await.unwrap().call(request).await.unwrap();
+
+        assert!(!response.headers().contains_key("helicone-provider"));
+    }
+
+    #[tokio::test]
+    async fn test_missing_provider_request_id_extension() {
+        let config = ResponseHeadersConfig {
+            provider: false,
+            provider_request_id: true,
+        };
+
+        let mut service = ResponseHeaderService::new(
+            config,
+            create_mock_service(|| Response::new("test".to_string())),
+        );
+
+        let request = Request::new(());
+        let response =
+            service.ready().await.unwrap().call(request).await.unwrap();
+
+        assert!(!response.headers().contains_key("helicone-provider-req-id"));
+    }
+}

--- a/llm-proxy/src/types/extensions.rs
+++ b/llm-proxy/src/types/extensions.rs
@@ -1,0 +1,2 @@
+#[derive(Debug, Clone)]
+pub struct ProviderRequestId(pub(crate) http::HeaderValue);

--- a/llm-proxy/src/types/mod.rs
+++ b/llm-proxy/src/types/mod.rs
@@ -1,5 +1,6 @@
 pub mod body;
 pub mod discover;
+pub mod extensions;
 pub mod json;
 pub mod logger;
 pub mod model_id;

--- a/llm-proxy/src/types/provider.rs
+++ b/llm-proxy/src/types/provider.rs
@@ -63,6 +63,7 @@ impl Serialize for ModelProvider {
     EnumIter,
     strum::Display,
     strum::EnumString,
+    strum::AsRefStr,
 )]
 #[strum(serialize_all = "kebab-case")]
 pub enum InferenceProvider {
@@ -119,7 +120,7 @@ impl Serialize for InferenceProvider {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        serializer.serialize_str(self.as_ref())
     }
 }
 


### PR DESCRIPTION
- Adds basic configurable response headers to give additional insight when developing or debugging. For now, this just includes the ultimately selecting upstream AI provider and their request id, but could be expanded in the future.