### PR TITLE
task: Audit error handling

### DIFF
--- a/llm-proxy/src/dispatcher/service.rs
+++ b/llm-proxy/src/dispatcher/service.rs
@@ -43,10 +43,7 @@ use crate::{
         router::RouterId,
         secret::Secret,
     },
-    utils::{
-        ResponseExt as _,
-        handle_error::{ErrorHandler, ErrorHandlerLayer},
-    },
+    utils::handle_error::{ErrorHandler, ErrorHandlerLayer},
 };
 
 pub type DispatcherFuture = BoxFuture<
@@ -345,7 +342,7 @@ impl Dispatcher {
             }
         }
 
-        response.error_for_status()
+        Ok(response)
     }
 
     fn dispatch_stream(

--- a/llm-proxy/src/middleware/mapper/service.rs
+++ b/llm-proxy/src/middleware/mapper/service.rs
@@ -228,6 +228,11 @@ async fn map_request_no_op(
         .await
         .map_err(InternalError::CollectBodyError)?
         .to_bytes();
+    // we still collect the body and call the converter in order to map the
+    // model name. eg if they send `model:
+    // anthropic/claude-3-5-sonnet-20240620` from the OpenAI sdk,
+    // and the only configured provider is OpenAI, we need to map the model name
+    // but not change the structure of the request body.
     let converter = converter_registry
         .get_converter(source_endpoint, target_endpoint)
         .ok_or_else(|| {

--- a/llm-proxy/src/router/meta.rs
+++ b/llm-proxy/src/router/meta.rs
@@ -127,6 +127,10 @@ impl tower::Service<crate::types::request::Request> for MetaRouter {
         let extracted_path_and_query = match extracted_path_and_query {
             Ok(path_and_query) => path_and_query,
             Err(_e) => {
+                // This should **never** happen theoretically since in order to
+                // get this far, the request uri should have
+                // been valid, and a subpath of that which
+                // we extract with the regex should also be valid.
                 tracing::warn!(
                     "Failed to convert extracted path to PathAndQuery"
                 );


### PR DESCRIPTION
- This commit audits Helix to ensure we try to: a) Don't hard error unless we have to b) If an upstream LLM provider errors, return errors in the JSON format returned by them rather than in our own custom format
- This commit also adds some comments to explain certain error cases