### PR TITLE
refactor: Better URLs for named routers

### DIFF
--- a/llm-proxy/src/app_state.rs
+++ b/llm-proxy/src/app_state.rs
@@ -67,12 +67,13 @@ pub struct InnerAppState {
 impl AppState {
     pub async fn get_rate_limit_tx(
         &self,
-        router_id: RouterId,
+        router_id: &RouterId,
     ) -> Result<Sender<RateLimitEvent>, InitError> {
         let rate_limit_channels = self.0.rate_limit_senders.read().await;
-        let rate_limit_tx = rate_limit_channels
-            .get(&router_id)
-            .ok_or(InitError::RateLimitChannelsNotInitialized(router_id))?;
+        let rate_limit_tx =
+            rate_limit_channels.get(router_id).ok_or_else(|| {
+                InitError::RateLimitChannelsNotInitialized(router_id.clone())
+            })?;
         Ok(rate_limit_tx.clone())
     }
 

--- a/llm-proxy/src/balancer/provider.rs
+++ b/llm-proxy/src/balancer/provider.rs
@@ -60,21 +60,25 @@ impl ProviderBalancer {
         let (rate_limit_tx, rate_limit_rx) = channel(CHANNEL_CAPACITY);
         let discover_factory = DiscoverFactory::new(
             app_state.clone(),
-            router_id,
+            router_id.clone(),
             router_config.clone(),
         );
         app_state
             .add_weighted_router_health_monitor(
-                router_id,
+                router_id.clone(),
                 router_config.clone(),
                 change_tx.clone(),
             )
             .await;
-        app_state.add_rate_limit_tx(router_id, rate_limit_tx).await;
-        app_state.add_rate_limit_rx(router_id, rate_limit_rx).await;
+        app_state
+            .add_rate_limit_tx(router_id.clone(), rate_limit_tx)
+            .await;
+        app_state
+            .add_rate_limit_rx(router_id.clone(), rate_limit_rx)
+            .await;
         app_state
             .add_weighted_router_rate_limit_monitor(
-                router_id,
+                router_id.clone(),
                 router_config,
                 change_tx,
             )
@@ -97,21 +101,25 @@ impl ProviderBalancer {
         let (rate_limit_tx, rate_limit_rx) = channel(CHANNEL_CAPACITY);
         let discover_factory = DiscoverFactory::new(
             app_state.clone(),
-            router_id,
+            router_id.clone(),
             router_config.clone(),
         );
         app_state
             .add_p2c_router_health_monitor(
-                router_id,
+                router_id.clone(),
                 router_config.clone(),
                 change_tx.clone(),
             )
             .await;
-        app_state.add_rate_limit_tx(router_id, rate_limit_tx).await;
-        app_state.add_rate_limit_rx(router_id, rate_limit_rx).await;
+        app_state
+            .add_rate_limit_tx(router_id.clone(), rate_limit_tx)
+            .await;
+        app_state
+            .add_rate_limit_rx(router_id.clone(), rate_limit_rx)
+            .await;
         app_state
             .add_p2c_router_rate_limit_monitor(
-                router_id,
+                router_id.clone(),
                 router_config,
                 change_tx,
             )

--- a/llm-proxy/src/config/validation.rs
+++ b/llm-proxy/src/config/validation.rs
@@ -52,7 +52,7 @@ impl Config {
                 if !self.providers.contains_key(provider) {
                     return Err(
                         ModelMappingValidationError::ProviderNotConfigured {
-                            router: *router_id,
+                            router: router_id.clone(),
                             provider: *provider,
                         },
                     );
@@ -122,7 +122,7 @@ impl Config {
         }
 
         Err(ModelMappingValidationError::NoValidMapping {
-            router: *router_id,
+            router: router_id.clone(),
             source_model: source_model.as_ref().to_string(),
             target_provider,
         })

--- a/llm-proxy/src/discover/monitor/health/provider.rs
+++ b/llm-proxy/src/discover/monitor/health/provider.rs
@@ -110,7 +110,7 @@ async fn check_weighted_monitor(
 
                         let service = Dispatcher::new(
                             inner.app_state.clone(),
-                            inner.router_id,
+                            &inner.router_id,
                             &inner.router_config,
                             provider,
                         )
@@ -178,7 +178,7 @@ async fn check_p2c_monitor(
 
                         let service = Dispatcher::new(
                             inner.app_state.clone(),
-                            inner.router_id,
+                            &inner.router_id,
                             &inner.router_config,
                             provider,
                         )
@@ -303,7 +303,6 @@ impl HealthMonitor {
             let mut check_futures = Vec::new();
             for (router_id, monitor) in monitors.iter_mut() {
                 let span = tracing::info_span!("health_monitor", router_id = ?router_id);
-                let router_id = *router_id;
                 let check_future = async move {
                     let result = monitor.check_monitor().await;
                     if let Err(e) = &result {
@@ -354,7 +353,7 @@ impl AppState {
         tx: Sender<Change<WeightedKey, DispatcherService>>,
     ) {
         self.0.health_monitors.write().await.insert(
-            router_id,
+            router_id.clone(),
             ProviderHealthMonitor::weighted(
                 tx,
                 router_id,
@@ -371,7 +370,7 @@ impl AppState {
         tx: Sender<Change<Key, DispatcherService>>,
     ) {
         self.0.health_monitors.write().await.insert(
-            router_id,
+            router_id.clone(),
             ProviderHealthMonitor::p2c(
                 tx,
                 router_id,

--- a/llm-proxy/src/discover/provider/config.rs
+++ b/llm-proxy/src/discover/provider/config.rs
@@ -52,7 +52,7 @@ pin_project! {
 impl ConfigDiscovery<Key> {
     pub async fn new(
         app_state: &AppState,
-        router_id: RouterId,
+        router_id: &RouterId,
         router_config: &Arc<RouterConfig>,
         rx: Receiver<Change<Key, DispatcherService>>,
     ) -> Result<Self, InitError> {
@@ -86,7 +86,7 @@ impl ConfigDiscovery<Key> {
 impl ConfigDiscovery<WeightedKey> {
     pub async fn new_weighted(
         app_state: &AppState,
-        router_id: RouterId,
+        router_id: &RouterId,
         router_config: &Arc<RouterConfig>,
         rx: Receiver<Change<WeightedKey, DispatcherService>>,
     ) -> Result<Self, InitError> {

--- a/llm-proxy/src/discover/provider/discover.rs
+++ b/llm-proxy/src/discover/provider/discover.rs
@@ -37,7 +37,7 @@ pin_project! {
 impl Discovery<Key> {
     pub async fn new(
         app_state: &AppState,
-        router_id: RouterId,
+        router_id: &RouterId,
         router_config: &Arc<RouterConfig>,
         rx: Receiver<Change<Key, DispatcherService>>,
     ) -> Result<Self, InitError> {
@@ -58,7 +58,7 @@ impl Discovery<Key> {
 impl Discovery<WeightedKey> {
     pub async fn new_weighted(
         app_state: &AppState,
-        router_id: RouterId,
+        router_id: &RouterId,
         router_config: &Arc<RouterConfig>,
         rx: Receiver<Change<WeightedKey, DispatcherService>>,
     ) -> Result<Self, InitError> {

--- a/llm-proxy/src/discover/provider/factory.rs
+++ b/llm-proxy/src/discover/provider/factory.rs
@@ -59,11 +59,11 @@ impl Service<Receiver<Change<Key, DispatcherService>>> for DiscoverFactory {
         rx: Receiver<Change<Key, DispatcherService>>,
     ) -> Self::Future {
         let app_state = self.app_state.clone();
-        let router_id = self.router_id;
+        let router_id = self.router_id.clone();
         let router_config = self.router_config.clone();
         Box::pin(async move {
             let discovery =
-                Discovery::new(&app_state, router_id, &router_config, rx)
+                Discovery::new(&app_state, &router_id, &router_config, rx)
                     .await?;
             let discovery = PeakEwmaDiscover::new(
                 discovery,

--- a/llm-proxy/src/discover/weighted/factory.rs
+++ b/llm-proxy/src/discover/weighted/factory.rs
@@ -33,12 +33,12 @@ impl Service<Receiver<Change<WeightedKey, DispatcherService>>>
         rx: Receiver<Change<WeightedKey, DispatcherService>>,
     ) -> Self::Future {
         let app_state = self.app_state.clone();
-        let router_id = self.router_id;
+        let router_id = self.router_id.clone();
         let router_config = self.router_config.clone();
         Box::pin(async move {
             let discovery = Discovery::new_weighted(
                 &app_state,
-                router_id,
+                &router_id,
                 &router_config,
                 rx,
             )

--- a/llm-proxy/src/error/init.rs
+++ b/llm-proxy/src/error/init.rs
@@ -56,4 +56,6 @@ pub enum InitError {
     RateLimitChannelsNotInitialized(RouterId),
     /// Failed to build websocket request: {0}
     WebsocketRequestBuild(#[from] http::Error),
+    /// Invalid router id: {0}
+    InvalidRouterId(String),
 }

--- a/llm-proxy/src/middleware/add_extension.rs
+++ b/llm-proxy/src/middleware/add_extension.rs
@@ -25,7 +25,7 @@ impl<S> Layer<S> for AddExtensionsLayer {
                 .endpoint_converter_registry
                 .clone(),
             inference_provider: self.inference_provider,
-            router_id: self.router_id,
+            router_id: self.router_id.clone(),
         }
     }
 }
@@ -58,7 +58,7 @@ where
         req.extensions_mut()
             .insert(self.endpoint_converter_registry.clone());
         req.extensions_mut().insert(self.inference_provider);
-        req.extensions_mut().insert(self.router_id);
+        req.extensions_mut().insert(self.router_id.clone());
         self.inner.call(req)
     }
 }

--- a/llm-proxy/src/router/service.rs
+++ b/llm-proxy/src/router/service.rs
@@ -61,18 +61,22 @@ impl Router {
         router_config.validate()?;
 
         let provider_keys =
-            Self::add_provider_keys(id, &router_config, &app_state).await?;
+            Self::add_provider_keys(id.clone(), &router_config, &app_state)
+                .await?;
 
         let mut inner = HashMap::default();
-        let rl_layer =
-            rate_limit::Layer::per_router(&app_state, id, &router_config)
-                .await?;
+        let rl_layer = rate_limit::Layer::per_router(
+            &app_state,
+            id.clone(),
+            &router_config,
+        )
+        .await?;
         for (endpoint_type, balance_config) in
             router_config.load_balance.as_ref()
         {
             let balancer = ProviderBalancer::new(
                 app_state.clone(),
-                id,
+                id.clone(),
                 router_config.clone(),
                 balance_config,
             )
@@ -92,7 +96,7 @@ impl Router {
         }
         let direct_proxy_dispatcher = Dispatcher::new(
             app_state.clone(),
-            id,
+            &id,
             &router_config,
             router_config.request_style,
         )

--- a/llm-proxy/src/types/router.rs
+++ b/llm-proxy/src/types/router.rs
@@ -1,23 +1,33 @@
 use chrono::{DateTime, Utc};
+use compact_str::CompactString;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::config::router::RouterConfig;
 
 #[derive(
-    Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default,
+    Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default,
 )]
 #[serde(rename_all = "kebab-case")]
 pub enum RouterId {
-    Uuid(Uuid),
+    Named(CompactString),
     #[default]
     Default,
+}
+
+impl AsRef<str> for RouterId {
+    fn as_ref(&self) -> &str {
+        match self {
+            RouterId::Named(name) => name.as_str(),
+            RouterId::Default => "default",
+        }
+    }
 }
 
 impl std::fmt::Display for RouterId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            RouterId::Uuid(uuid) => write!(f, "{uuid}"),
+            RouterId::Named(name) => write!(f, "{name}"),
             RouterId::Default => write!(f, "default"),
         }
     }
@@ -40,7 +50,7 @@ mod tests {
 
     #[test]
     fn router_id_round_trip() {
-        let id = RouterId::Uuid(Uuid::new_v4());
+        let id = RouterId::Named(CompactString::new("test_name"));
         let serialized = serde_json::to_string(&id).unwrap();
         let deserialized =
             serde_json::from_str::<RouterId>(&serialized).unwrap();

--- a/llm-proxy/tests/auth.rs
+++ b/llm-proxy/tests/auth.rs
@@ -44,7 +44,7 @@ async fn require_auth_enabled_with_valid_token() {
     let request = Request::builder()
         .method(Method::POST)
         .header("authorization", "Bearer sk-helicone-test-key")
-        .uri("http://router.helicone.com/router/v1/chat/completions")
+        .uri("http://router.helicone.com/router/default/v1/chat/completions")
         .body(request_body)
         .unwrap();
 
@@ -98,7 +98,7 @@ async fn require_auth_enabled_without_token() {
     let request = Request::builder()
         .method(Method::POST)
         // Missing authorization header
-        .uri("http://router.helicone.com/router/v1/chat/completions")
+        .uri("http://router.helicone.com/router/default/v1/chat/completions")
         .body(request_body)
         .unwrap();
 
@@ -145,7 +145,7 @@ async fn require_auth_disabled_without_token() {
     let request = Request::builder()
         .method(Method::POST)
         // No authorization header, but auth is disabled
-        .uri("http://router.helicone.com/router/v1/chat/completions")
+        .uri("http://router.helicone.com/router/default/v1/chat/completions")
         .body(request_body)
         .unwrap();
 
@@ -192,7 +192,7 @@ async fn require_auth_disabled_with_token() {
     let request = Request::builder()
         .method(Method::POST)
         .header("authorization", "Bearer sk-helicone-test-key")
-        .uri("http://router.helicone.com/router/v1/chat/completions")
+        .uri("http://router.helicone.com/router/default/v1/chat/completions")
         .body(request_body)
         .unwrap();
 

--- a/llm-proxy/tests/health_monitor.rs
+++ b/llm-proxy/tests/health_monitor.rs
@@ -87,7 +87,9 @@ async fn errors_remove_provider_from_lb_pool() {
             .method(Method::POST)
             .header("authorization", "Bearer sk-helicone-test-key")
             // default router
-            .uri("http://router.helicone.com/router/v1/chat/completions")
+            .uri(
+                "http://router.helicone.com/router/default/v1/chat/completions",
+            )
             .body(request_body)
             .unwrap();
         let response = harness.call(request).await.unwrap();

--- a/llm-proxy/tests/load_balance.rs
+++ b/llm-proxy/tests/load_balance.rs
@@ -84,7 +84,9 @@ async fn openai_slow() {
         let request = Request::builder()
             .method(Method::POST)
             // default router
-            .uri("http://router.helicone.com/router/v1/chat/completions")
+            .uri(
+                "http://router.helicone.com/router/default/v1/chat/completions",
+            )
             .body(request_body)
             .unwrap();
         let response = harness.call(request).await.unwrap();
@@ -137,7 +139,9 @@ async fn anthropic_slow() {
         let request = Request::builder()
             .method(Method::POST)
             // default router
-            .uri("http://router.helicone.com/router/v1/chat/completions")
+            .uri(
+                "http://router.helicone.com/router/default/v1/chat/completions",
+            )
             .body(request_body)
             .unwrap();
         let response = harness.call(request).await.unwrap();

--- a/llm-proxy/tests/logger.rs
+++ b/llm-proxy/tests/logger.rs
@@ -44,7 +44,7 @@ async fn request_response_logger_authenticated() {
     let request = Request::builder()
         .method(Method::POST)
         .header("authorization", "Bearer sk-helicone-test-key")
-        .uri("http://router.helicone.com/router/v1/chat/completions")
+        .uri("http://router.helicone.com/router/default/v1/chat/completions")
         .body(request_body)
         .unwrap();
     let response = harness.call(request).await.unwrap();
@@ -92,7 +92,7 @@ async fn request_response_logger_unauthenticated() {
     let request = Request::builder()
         .method(Method::POST)
         // No authorization header when auth is not required
-        .uri("http://router.helicone.com/router/v1/chat/completions")
+        .uri("http://router.helicone.com/router/default/v1/chat/completions")
         .body(request_body)
         .unwrap();
     let response = harness.call(request).await.unwrap();

--- a/llm-proxy/tests/passthrough.rs
+++ b/llm-proxy/tests/passthrough.rs
@@ -61,7 +61,7 @@ async fn openai_passthrough() {
     let request = Request::builder()
         .method(Method::POST)
         // Route to the fake endpoint through the default router
-        .uri("http://router.helicone.com/router/v1/fake_endpoint")
+        .uri("http://router.helicone.com/router/default/v1/fake_endpoint")
         .header("content-type", "application/json")
         .body(request_body)
         .unwrap();

--- a/llm-proxy/tests/rate_limit.rs
+++ b/llm-proxy/tests/rate_limit.rs
@@ -262,7 +262,7 @@ async fn make_chat_request(
     let request = Request::builder()
         .method(Method::POST)
         .header("authorization", auth_header)
-        .uri("http://router.helicone.com/router/v1/chat/completions")
+        .uri("http://router.helicone.com/router/default/v1/chat/completions")
         .body(request_body)
         .unwrap();
 

--- a/llm-proxy/tests/rate_limit_monitor.rs
+++ b/llm-proxy/tests/rate_limit_monitor.rs
@@ -97,7 +97,9 @@ async fn rate_limit_removes_provider_from_lb_pool() {
         let request = Request::builder()
             .method(Method::POST)
             .header("authorization", "Bearer sk-helicone-test-key")
-            .uri("http://router.helicone.com/router/v1/chat/completions")
+            .uri(
+                "http://router.helicone.com/router/default/v1/chat/completions",
+            )
             .body(request_body)
             .unwrap();
         let response = harness.call(request).await.unwrap();
@@ -127,7 +129,9 @@ async fn rate_limit_removes_provider_from_lb_pool() {
         let request = Request::builder()
             .method(Method::POST)
             .header("authorization", "Bearer sk-helicone-test-key")
-            .uri("http://router.helicone.com/router/v1/chat/completions")
+            .uri(
+                "http://router.helicone.com/router/default/v1/chat/completions",
+            )
             .body(request_body)
             .unwrap();
         let response = harness.call(request).await.unwrap();

--- a/llm-proxy/tests/single_provider.rs
+++ b/llm-proxy/tests/single_provider.rs
@@ -52,7 +52,7 @@ async fn openai() {
     let request = Request::builder()
         .method(Method::POST)
         // default router
-        .uri("http://router.helicone.com/router/v1/chat/completions")
+        .uri("http://router.helicone.com/router/default/v1/chat/completions")
         .body(request_body)
         .unwrap();
     let response = harness.call(request).await.unwrap();
@@ -104,7 +104,7 @@ async fn google_with_openai_request_style() {
     let request = Request::builder()
         .method(Method::POST)
         // default router
-        .uri("http://router.helicone.com/router/v1/chat/completions")
+        .uri("http://router.helicone.com/router/default/v1/chat/completions")
         .body(request_body)
         .unwrap();
     let response = harness.call(request).await.unwrap();
@@ -122,7 +122,7 @@ async fn google_with_openai_request_style() {
     let request = Request::builder()
         .method(Method::POST)
         // default router
-        .uri("http://router.helicone.com/router/v1/chat/completions")
+        .uri("http://router.helicone.com/router/default/v1/chat/completions")
         .body(request_body)
         .unwrap();
     let response = harness.call(request).await.unwrap();
@@ -177,7 +177,7 @@ async fn anthropic_with_openai_request_style() {
     let request = Request::builder()
         .method(Method::POST)
         // default router
-        .uri("http://router.helicone.com/router/v1/chat/completions")
+        .uri("http://router.helicone.com/router/default/v1/chat/completions")
         .body(request_body)
         .unwrap();
     let response = harness.call(request).await.unwrap();
@@ -199,7 +199,7 @@ async fn anthropic_with_openai_request_style() {
     let request = Request::builder()
         .method(Method::POST)
         // default router
-        .uri("http://router.helicone.com/router/v1/chat/completions")
+        .uri("http://router.helicone.com/router/default/v1/chat/completions")
         .body(request_body)
         .unwrap();
     let response = harness.call(request).await.unwrap();
@@ -252,7 +252,7 @@ async fn anthropic_with_anthropic_request_style() {
     let request = Request::builder()
         .method(Method::POST)
         // default router
-        .uri("http://router.helicone.com/router/v1/chat/completions")
+        .uri("http://router.helicone.com/router/default/v1/chat/completions")
         .body(request_body)
         .unwrap();
     let response = harness.call(request).await.unwrap();
@@ -274,7 +274,7 @@ async fn anthropic_with_anthropic_request_style() {
     let request = Request::builder()
         .method(Method::POST)
         // default router
-        .uri("http://router.helicone.com/router/v1/chat/completions")
+        .uri("http://router.helicone.com/router/default/v1/chat/completions")
         .body(request_body)
         .unwrap();
     let response = harness.call(request).await.unwrap();
@@ -330,7 +330,7 @@ async fn anthropic_request_style() {
     let request = Request::builder()
         .method(Method::POST)
         // default router
-        .uri("http://router.helicone.com/router/v1/messages")
+        .uri("http://router.helicone.com/router/default/v1/messages")
         .body(request_body)
         .unwrap();
     let response = harness.call(request).await.unwrap();
@@ -385,7 +385,7 @@ async fn ollama() {
     let request = Request::builder()
         .method(Method::POST)
         // default router
-        .uri("http://router.helicone.com/router/v1/chat/completions")
+        .uri("http://router.helicone.com/router/default/v1/chat/completions")
         .body(request_body)
         .unwrap();
     let response = harness.call(request).await.unwrap();

--- a/llm-proxy/tests/weighted_balance.rs
+++ b/llm-proxy/tests/weighted_balance.rs
@@ -76,7 +76,9 @@ async fn weighted_balancer_anthropic_preferred() {
         let request = Request::builder()
             .method(Method::POST)
             // default router
-            .uri("http://router.helicone.com/router/v1/chat/completions")
+            .uri(
+                "http://router.helicone.com/router/default/v1/chat/completions",
+            )
             .body(request_body)
             .unwrap();
         let response = harness.call(request).await.unwrap();
@@ -149,7 +151,9 @@ async fn weighted_balancer_openai_preferred() {
         let request = Request::builder()
             .method(Method::POST)
             // default router
-            .uri("http://router.helicone.com/router/v1/chat/completions")
+            .uri(
+                "http://router.helicone.com/router/default/v1/chat/completions",
+            )
             .body(request_body)
             .unwrap();
         let response = harness.call(request).await.unwrap();
@@ -222,7 +226,9 @@ async fn weighted_balancer_anthropic_heavily_preferred() {
         let request = Request::builder()
             .method(Method::POST)
             // default router
-            .uri("http://router.helicone.com/router/v1/chat/completions")
+            .uri(
+                "http://router.helicone.com/router/default/v1/chat/completions",
+            )
             .body(request_body)
             .unwrap();
         let response = harness.call(request).await.unwrap();
@@ -310,7 +316,9 @@ async fn weighted_balancer_equal_four_providers() {
         let request = Request::builder()
             .method(Method::POST)
             // default router
-            .uri("http://router.helicone.com/router/v1/chat/completions")
+            .uri(
+                "http://router.helicone.com/router/default/v1/chat/completions",
+            )
             .body(request_body)
             .unwrap();
         let response = harness.call(request).await.unwrap();

--- a/scripts/test/src/main.rs
+++ b/scripts/test/src/main.rs
@@ -43,7 +43,7 @@ pub async fn test(run_forever_mode: bool) {
     let helicone_api_key = std::env::var("HELICONE_API_KEY").unwrap();
 
     let response = reqwest::Client::new()
-        .post("http://localhost:5678/router/v1/chat/completions")
+        .post("http://localhost:5678/router/default/v1/chat/completions")
         .header("Content-Type", "application/json")
         .header("authorization", helicone_api_key)
         .body(bytes)

--- a/scripts/trace-test-client/src/main.rs
+++ b/scripts/trace-test-client/src/main.rs
@@ -100,7 +100,7 @@ async fn main()
     let logger_provider = init_logs();
 
     send_request(
-        "http://localhost:5678/router/v1/chat/completions",
+        "http://localhost:5678/router/default/v1/chat/completions",
         r#"{
             "model": "gpt-4o-mini",
             "messages": [


### PR DESCRIPTION
This commit updates the Router URL to match the following format:

- `/router/{name}`
- `/router/{name}?{query}`
- `/router/{name}/{path}`
- `/router/{name}/{path}?{query}`

eg:
- `/router/default`
- `/router/my-router`
- `/router/my-router?user=bar`
- `/router/default/v1/chat/completions`
- `/router/my-router/v1/chat/completions`
- `/router/my-router/v1/chat/completions?user=test&limit=10`

this means that the URL `/router/default/v1/chat/completions` is no longer supported in order to disambiguate between routers