### PR TITLE
feat: Better config logging

### DIFF
--- a/llm-proxy/src/app.rs
+++ b/llm-proxy/src/app.rs
@@ -171,7 +171,7 @@ impl tower::Service<crate::types::request::Request> for App {
 
 impl App {
     pub async fn new(config: Config) -> Result<Self, InitError> {
-        tracing::info!(config = ?config, "creating app");
+        tracing::info!("creating app");
         let minio = Minio::new(config.minio.clone())?;
 
         let jawn_http_client = JawnClient::new()?;

--- a/llm-proxy/src/config/helicone.rs
+++ b/llm-proxy/src/config/helicone.rs
@@ -15,7 +15,7 @@ pub struct HeliconeConfig {
 impl Default for HeliconeConfig {
     fn default() -> Self {
         Self {
-            api_key: Secret(
+            api_key: Secret::from(
                 std::env::var("HELICONE_API_KEY")
                     .unwrap_or("sk-helicone-...".to_string()),
             ),

--- a/llm-proxy/src/config/minio.rs
+++ b/llm-proxy/src/config/minio.rs
@@ -86,8 +86,10 @@ impl Minio {
             .tcp_nodelay(true)
             .build()
             .map_err(InitError::CreateReqwestClient)?;
-        let credentials =
-            Credentials::new(config.access_key.0, config.secret_key.0);
+        let credentials = Credentials::new(
+            config.access_key.expose(),
+            config.secret_key.expose(),
+        );
         Ok(Self {
             bucket,
             client,
@@ -124,11 +126,11 @@ fn default_region() -> String {
 }
 
 fn default_access_key() -> Secret<String> {
-    Secret("minioadmin".to_string())
+    Secret::from("minioadmin".to_string())
 }
 
 fn default_secret_key() -> Secret<String> {
-    Secret("minioadmin".to_string())
+    Secret::from("minioadmin".to_string())
 }
 
 #[cfg(feature = "testing")]

--- a/llm-proxy/src/config/redis.rs
+++ b/llm-proxy/src/config/redis.rs
@@ -23,7 +23,7 @@ impl Default for RedisConfig {
 }
 
 fn default_url() -> Secret<String> {
-    Secret("redis://localhost:6379".to_string())
+    Secret::from("redis://localhost:6379".to_string())
 }
 
 fn default_connection_timeout() -> Duration {

--- a/llm-proxy/src/control_plane/websocket.rs
+++ b/llm-proxy/src/control_plane/websocket.rs
@@ -72,7 +72,10 @@ impl IntoClientRequest for &HeliconeConfig {
         Request::builder()
             .uri(self.websocket_url.as_str())
             .header("Host", host_header)
-            .header("Authorization", format!("Bearer {}", self.api_key.0))
+            .header(
+                "Authorization",
+                format!("Bearer {}", self.api_key.expose()),
+            )
             .header("Connection", "Upgrade")
             .header("Upgrade", "websocket")
             .header("Sec-WebSocket-Version", "13")

--- a/llm-proxy/src/dispatcher/anthropic_client.rs
+++ b/llm-proxy/src/dispatcher/anthropic_client.rs
@@ -36,7 +36,7 @@ impl Client {
         let mut default_headers = HeaderMap::new();
         default_headers.insert(
             HeaderName::from_static("x-api-key"),
-            HeaderValue::from_str(&api_key.0).unwrap(),
+            HeaderValue::from_str(api_key.expose()).unwrap(),
         );
         default_headers.insert(
             HeaderName::from_static("anthropic-version"),

--- a/llm-proxy/src/dispatcher/google_gemini_client.rs
+++ b/llm-proxy/src/dispatcher/google_gemini_client.rs
@@ -31,7 +31,8 @@ impl Client {
         let mut default_headers = HeaderMap::new();
         default_headers.insert(
             http::header::AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {}", api_key.0)).unwrap(),
+            HeaderValue::from_str(&format!("Bearer {}", api_key.expose()))
+                .unwrap(),
         );
         default_headers.insert(http::header::HOST, host_header(&base_url));
         default_headers.insert(

--- a/llm-proxy/src/dispatcher/openai_client.rs
+++ b/llm-proxy/src/dispatcher/openai_client.rs
@@ -31,7 +31,8 @@ impl Client {
         let mut default_headers = HeaderMap::new();
         default_headers.insert(
             http::header::AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {}", api_key.0)).unwrap(),
+            HeaderValue::from_str(&format!("Bearer {}", api_key.expose()))
+                .unwrap(),
         );
         default_headers.insert(http::header::HOST, host_header(&base_url));
         default_headers.insert(

--- a/llm-proxy/src/main.rs
+++ b/llm-proxy/src/main.rs
@@ -44,6 +44,9 @@ async fn main() -> Result<(), RuntimeError> {
             .map_err(InitError::Telemetry)?;
 
     info!("telemetry initialized");
+    let pretty_config = serde_yml::to_string(&config)
+        .expect("config should always be serializable");
+    info!(config = pretty_config, "starting up with config");
 
     config.validate().inspect_err(|e| {
         tracing::error!(error = %e, "configuration validation failed");

--- a/llm-proxy/src/types/provider.rs
+++ b/llm-proxy/src/types/provider.rs
@@ -160,7 +160,7 @@ impl ProviderKeys {
                     provider = %provider,
                     "Got provider key"
                 );
-                keys.insert(provider, Secret(key));
+                keys.insert(provider, Secret::from(key));
             } else {
                 return Err(ProviderError::ApiKeyNotFound(provider));
             }
@@ -181,7 +181,7 @@ impl ProviderKeys {
                 provider = %default_provider,
                 "Got provider key for load balanced router"
             );
-            keys.insert(default_provider, Secret(key));
+            keys.insert(default_provider, Secret::from(key));
         } else {
             return Err(ProviderError::ApiKeyNotFound(default_provider));
         }
@@ -203,7 +203,7 @@ impl ProviderKeys {
                         provider = %provider,
                         "Got direct proxy provider key"
                     );
-                    keys.insert(*provider, Secret(key));
+                    keys.insert(*provider, Secret::from(key));
                 } else {
                     return Err(ProviderError::ApiKeyNotFound(*provider));
                 }

--- a/llm-proxy/src/types/secret.rs
+++ b/llm-proxy/src/types/secret.rs
@@ -8,17 +8,29 @@ use std::{
 /// This type can be used to wrap secrets without worrying about accidentally
 /// logging or serializing them. This type cannot be serialized, and its
 /// [`Debug`] implementation doesn't contain anything from the inner type.
-#[derive(
-    Default,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    Hash,
-    serde::Deserialize,
-    serde::Serialize,
-)]
-pub struct Secret<T>(pub T);
+#[derive(Default, Clone, Copy, PartialEq, Eq, Hash, serde::Deserialize)]
+pub struct Secret<T>(T);
+
+impl<T> Secret<T> {
+    pub fn expose(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> From<T> for Secret<T> {
+    fn from(value: T) -> Self {
+        Self(value)
+    }
+}
+
+impl<T> serde::Serialize for Secret<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str("*****")
+    }
+}
 
 impl<T> Debug for Secret<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
- Secret type improvements to be more explicit and to print `***` during serialization
- Only log config when running the Helicone router binary and not simply creating the app to avoid large unnecessary logs during tests
- Print config prettified yaml instead of debug for improved readability