### PR TITLE
feat: Track TFFT

### DIFF
--- a/.cargo-husky/hooks/commit-msg
+++ b/.cargo-husky/hooks/commit-msg
@@ -19,7 +19,7 @@ if ! echo "$first_line" | grep -Eqi "$pattern"; then
 
       <type>(<scope>)?: <subject>
 
-  • type: one of build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test  
+  • type: one of task, build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test  
   • scope: optional, alphanumeric/hyphen/underscore  
   • subject: 1–80 characters  
 

--- a/.cargo-husky/hooks/pre-push
+++ b/.cargo-husky/hooks/pre-push
@@ -9,4 +9,3 @@ set -e
 
 echo 'Running pre-push hooks'
 cargo +nightly fmt -- --check
-cargo c

--- a/llm-proxy/src/control_plane/websocket.rs
+++ b/llm-proxy/src/control_plane/websocket.rs
@@ -194,7 +194,7 @@ impl meltdown::Service for ControlPlaneClient {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{sync::Arc, time::Duration};
 
     use tokio::net::TcpListener;
     use tokio_tungstenite::accept_async;
@@ -225,8 +225,7 @@ mod tests {
 
         // Test connection
         let result =
-            ControlPlaneClient::connect(Default::default(), helicone_config)
-                .await;
+            ControlPlaneClient::connect(Arc::default(), helicone_config).await;
         assert!(result.is_ok(), "Should connect to mock server");
     }
 
@@ -236,8 +235,7 @@ mod tests {
 
         // This will fail if no server is running on 8585, which is expected
         let result =
-            ControlPlaneClient::connect(Default::default(), helicone_config)
-                .await;
+            ControlPlaneClient::connect(Arc::default(), helicone_config).await;
 
         if let Ok(mut client) = result {
             // If we can connect, try sending a heartbeat

--- a/llm-proxy/src/logger/service.rs
+++ b/llm-proxy/src/logger/service.rs
@@ -5,8 +5,10 @@ use chrono::Utc;
 use http::{HeaderMap, StatusCode};
 use http_body_util::BodyExt;
 use indexmap::IndexMap;
+use opentelemetry::KeyValue;
 use reqwest::Client;
 use rusty_s3::S3Action;
+use tokio::{sync::oneshot, time::Instant};
 use typed_builder::TypedBuilder;
 use url::Url;
 use uuid::Uuid;
@@ -14,9 +16,10 @@ use uuid::Uuid;
 use crate::{
     app_state::AppState,
     error::{init::InitError, logger::LoggerError},
+    metrics::tfft::TFFTFuture,
     types::{
         body::BodyReader,
-        extensions::{AuthContext, RequestContext},
+        extensions::{AuthContext, MapperContext, RequestContext},
         logger::{
             HeliconeLogMetadata, Log, LogMessage, RequestLog, ResponseLog,
             S3Log,
@@ -55,6 +58,9 @@ pub struct LoggerService {
     request_headers: HeaderMap,
     response_status: StatusCode,
     provider: InferenceProvider,
+    mapper_ctx: MapperContext,
+    request_start: Instant,
+    tfft_rx: oneshot::Receiver<()>,
 }
 
 impl LoggerService {
@@ -98,7 +104,7 @@ impl LoggerService {
     }
 
     #[tracing::instrument(skip_all)]
-    #[allow(clippy::cast_precision_loss)]
+    #[allow(clippy::cast_precision_loss, clippy::too_many_lines)]
     pub async fn log(mut self) -> Result<(), LoggerError> {
         tracing::trace!("logging request");
         let auth_ctx = self
@@ -106,13 +112,18 @@ impl LoggerService {
             .auth_context
             .as_ref()
             .ok_or(LoggerError::NoAuthContextSet)?;
-        let response_body = self
-            .response_body
-            .collect()
-            .await
+        let tfft_future = TFFTFuture::new(self.request_start, self.tfft_rx);
+        let collect_future = self.response_body.collect();
+        let (response_body, tfft_duration) =
+            tokio::join!(collect_future, tfft_future);
+        let response_body = response_body
             .inspect_err(|_| tracing::error!("infallible errored"))
             .expect("infallible never errors")
             .to_bytes();
+        let tfft_duration = tfft_duration.unwrap_or_else(|_| {
+            tracing::error!("Failed to get TFFT signal");
+            Duration::from_secs(0)
+        });
         let req_body_len = self.request_body.len();
         let resp_body_len = response_body.len();
         let request_id = Uuid::new_v4();
@@ -124,6 +135,21 @@ impl LoggerService {
             response_body,
         )
         .await?;
+
+        let model = self.mapper_ctx.model.as_ref().map_or_else(
+            || "unknown".to_string(),
+            std::string::ToString::to_string,
+        );
+        let attributes = [
+            KeyValue::new("provider", self.provider.to_string()),
+            KeyValue::new("model", model),
+            KeyValue::new("path", self.target_url.path().to_string()),
+        ];
+        self.app_state
+            .0
+            .metrics
+            .tfft_duration
+            .record(tfft_duration.as_millis() as f64, &attributes);
 
         let helicone_metadata =
             HeliconeLogMetadata::from_headers(&mut self.request_headers)?;
@@ -144,7 +170,7 @@ impl LoggerService {
             .status(f64::from(self.response_status.as_u16()))
             .body_size(resp_body_len as f64)
             .response_created_at(Utc::now())
-            .delay_ms(0.0)
+            .delay_ms(tfft_duration.as_millis() as f64)
             .build();
         let log = Log::new(request_log, response_log);
         let log_message = LogMessage::builder()

--- a/llm-proxy/src/metrics/mod.rs
+++ b/llm-proxy/src/metrics/mod.rs
@@ -2,8 +2,9 @@ pub mod attribute_extractor;
 pub mod request_count;
 pub mod rolling_counter;
 pub mod system;
+pub mod tfft;
 
-use opentelemetry::metrics::{Counter, Gauge, Meter};
+use opentelemetry::metrics::{Counter, Gauge, Histogram, Meter};
 
 pub use self::rolling_counter::RollingCounter;
 
@@ -17,6 +18,7 @@ pub struct Metrics {
     pub auth_rejections: Counter<u64>,
     pub request_count: Counter<u64>,
     pub response_count: Counter<u64>,
+    pub tfft_duration: Histogram<f64>,
 }
 
 impl Metrics {
@@ -46,6 +48,11 @@ impl Metrics {
             .u64_counter("response_count")
             .with_description("Number of successful responses")
             .build();
+        let tfft_duration = meter
+            .f64_histogram("tfft_duration")
+            .with_unit("ms")
+            .with_description("Time to first token duration")
+            .build();
         Self {
             error_count,
             provider_health,
@@ -53,6 +60,7 @@ impl Metrics {
             auth_rejections,
             request_count,
             response_count,
+            tfft_duration,
         }
     }
 }

--- a/llm-proxy/src/metrics/tfft.rs
+++ b/llm-proxy/src/metrics/tfft.rs
@@ -1,0 +1,42 @@
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use futures::ready;
+use pin_project_lite::pin_project;
+use tokio::{
+    sync::oneshot::{self, error::RecvError},
+    time::Instant,
+};
+
+pin_project! {
+    pub struct TFFTFuture {
+        start_time: Instant,
+        #[pin]
+        tfft_rx: oneshot::Receiver<()>,
+    }
+}
+
+impl TFFTFuture {
+    #[must_use]
+    pub fn new(start_time: Instant, tfft_rx: oneshot::Receiver<()>) -> Self {
+        Self {
+            start_time,
+            tfft_rx,
+        }
+    }
+}
+
+impl Future for TFFTFuture {
+    type Output = Result<Duration, RecvError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        match ready!(this.tfft_rx.poll(cx)) {
+            Ok(()) => Poll::Ready(Ok(this.start_time.elapsed())),
+            Err(e) => Poll::Ready(Err(e)),
+        }
+    }
+}

--- a/llm-proxy/src/types/body.rs
+++ b/llm-proxy/src/types/body.rs
@@ -8,7 +8,10 @@ pub use axum_core::body::Body;
 use bytes::{BufMut, Bytes, BytesMut};
 use futures::{Stream, StreamExt};
 use hyper::body::{Body as _, Frame, SizeHint};
-use tokio::sync::mpsc::{self, UnboundedReceiver};
+use tokio::sync::{
+    mpsc::{self, UnboundedReceiver},
+    oneshot,
+};
 
 use crate::error::internal::InternalError;
 
@@ -16,6 +19,7 @@ use crate::error::internal::InternalError;
 #[derive(Debug)]
 pub struct BodyReader {
     rx: UnboundedReceiver<Bytes>,
+    tfft_tx: Option<oneshot::Sender<()>>,
     is_end_stream: bool,
     size_hint: SizeHint,
     append_newlines: bool,
@@ -25,11 +29,13 @@ impl BodyReader {
     #[must_use]
     pub fn new(
         rx: UnboundedReceiver<Bytes>,
+        tfft_tx: oneshot::Sender<()>,
         size_hint: SizeHint,
         append_newlines: bool,
     ) -> Self {
         Self {
             rx,
+            tfft_tx: Some(tfft_tx),
             is_end_stream: false,
             size_hint,
             append_newlines,
@@ -41,10 +47,11 @@ impl BodyReader {
     pub fn wrap_stream(
         stream: impl Stream<Item = Result<Bytes, InternalError>> + Send + 'static,
         append_newlines: bool,
-    ) -> (axum_core::body::Body, BodyReader) {
+    ) -> (axum_core::body::Body, BodyReader, oneshot::Receiver<()>) {
         // unbounded channel is okay since we limit memory usage higher in the
         // stack by limiting concurrency and request/response body size.
         let (tx, rx) = mpsc::unbounded_channel();
+        let (tfft_tx, tfft_rx) = oneshot::channel();
         let s = stream.map(move |b| {
             match &b {
                 Ok(b) => {
@@ -60,7 +67,11 @@ impl BodyReader {
         });
         let inner = axum_core::body::Body::from_stream(s);
         let size_hint = inner.size_hint();
-        (inner, BodyReader::new(rx, size_hint, append_newlines))
+        (
+            inner,
+            BodyReader::new(rx, tfft_tx, size_hint, append_newlines),
+            tfft_rx,
+        )
     }
 }
 
@@ -74,6 +85,12 @@ impl hyper::body::Body for BodyReader {
     ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
         match Pin::new(&mut self.rx).poll_recv(cx) {
             Poll::Ready(Some(bytes)) => {
+                if let Some(tfft_tx) = self.tfft_tx.take() {
+                    if let Err(()) = tfft_tx.send(()) {
+                        tracing::error!("Failed to send TFFT signal");
+                    }
+                }
+
                 if self.append_newlines {
                     let mut new_bytes = BytesMut::from(bytes);
                     new_bytes.put("\n".as_bytes());


### PR DESCRIPTION
- Adds a `tokio::oneshot` channel to the `BodyReader` which asynchronously tracks when the first data frame of the HTTP response is received in order to track the time to first byte / time to first token as seen from the router itself
- Update LLM observability to use the actual TFFT time
- Add opentelemetry metrics to track TFFT via OTel