### PR TITLE
refactor: SelfHosted -> Sidecar deployment target

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ This is an LLM proxy/router service that forwards API requests to providers like
 5. **Configuration**:
    - Config is loaded from file and/or environment variables
    - Database, MinIO, server, provider, router config sections
-   - Supports different deployment targets (Cloud, Sidecar, SelfHosted)
+   - Supports different deployment targets (Cloud, Sidecar)
 
 6. **Telemetry**:
    - Tracing with OpenTelemetry support

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "ai-gateway"
-version = "0.2.0-beta.0"
+version = "0.2.0-beta.1"
 dependencies = [
  "anthropic-ai-sdk",
  "async-openai",
@@ -3000,7 +3000,7 @@ dependencies = [
 
 [[package]]
 name = "mock-server"
-version = "0.2.0-beta.0"
+version = "0.2.0-beta.1"
 dependencies = [
  "ai-gateway",
  "tokio",
@@ -5025,7 +5025,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "telemetry"
-version = "0.2.0-beta.0"
+version = "0.2.0-beta.1"
 dependencies = [
  "http 1.3.1",
  "log-panics",
@@ -5970,7 +5970,7 @@ dependencies = [
 
 [[package]]
 name = "weighted-balance"
-version = "0.2.0-beta.0"
+version = "0.2.0-beta.1"
 dependencies = [
  "futures",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2024"
 authors = [ "Thomas Harmon <tom@helicone.ai>, Justin Torre <justin@helicone.ai>, Kavin Desi Valli <kavin@helicone.ai>, Charlie Wu <charlie@helicone.ai>", "Helicone Developers" ]
 license = "UNLICENSED"
 publish = false
-version = "0.2.0-beta.0"
+version = "0.2.0-beta.1"
 
 [profile.release]
 opt-level = 3

--- a/ai-gateway/src/config/mod.rs
+++ b/ai-gateway/src/config/mod.rs
@@ -47,7 +47,6 @@ pub enum Error {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub enum DeploymentTarget {
     Cloud,
-    SelfHosted,
     #[default]
     Sidecar,
 }
@@ -126,7 +125,7 @@ impl Config {
             }
         }
         self.validate_model_mappings()?;
-        if matches!(self.deployment_target, DeploymentTarget::SelfHosted)
+        if matches!(self.deployment_target, DeploymentTarget::Cloud)
             && self.minio.is_none()
         {
             return Err(InitError::MinioNotConfigured);

--- a/ai-gateway/src/error/init.rs
+++ b/ai-gateway/src/error/init.rs
@@ -3,7 +3,7 @@ use telemetry::TelemetryError;
 use thiserror::Error;
 
 use crate::{
-    config::{DeploymentTarget, validation::ModelMappingValidationError},
+    config::validation::ModelMappingValidationError,
     types::{provider::InferenceProvider, router::RouterId},
 };
 
@@ -12,8 +12,6 @@ use crate::{
 pub enum InitError {
     /// Default router not found
     DefaultRouterNotFound,
-    /// Deployment target not supported: {0:?}
-    DeploymentTargetNotSupported(DeploymentTarget),
     /// Failed to read TLS certificate: {0}
     Tls(std::io::Error),
     /// Failed to bind to address: {0}

--- a/ai-gateway/src/logger/service.rs
+++ b/ai-gateway/src/logger/service.rs
@@ -88,7 +88,7 @@ impl LoggerService {
         let resp_body_len = response_body.len();
         let request_id = Uuid::new_v4();
         let s3_client = match self.app_state.config().deployment_target {
-            DeploymentTarget::SelfHosted => S3Client::self_hosted(
+            DeploymentTarget::Cloud => S3Client::cloud(
                 self.app_state
                     .0
                     .minio
@@ -98,7 +98,6 @@ impl LoggerService {
             DeploymentTarget::Sidecar => {
                 S3Client::sidecar(&self.app_state.0.jawn_http_client)
             }
-            DeploymentTarget::Cloud => todo!("cloud is not yet supported"),
         };
         s3_client
             .log_bodies(

--- a/ai-gateway/src/router/meta.rs
+++ b/ai-gateway/src/router/meta.rs
@@ -64,13 +64,11 @@ pub struct MetaRouter {
 impl MetaRouter {
     pub async fn new(app_state: AppState) -> Result<Self, InitError> {
         let meta_router = match app_state.0.config.deployment_target {
-            DeploymentTarget::SelfHosted | DeploymentTarget::Sidecar => {
+            DeploymentTarget::Cloud | DeploymentTarget::Sidecar => {
+                // Note: Cloud will eventually get router configs from the
+                // database, but for not we are just allowing
+                // the cloud to be deployed to start dogfooding
                 Self::from_config(app_state).await
-            }
-            DeploymentTarget::Cloud => {
-                return Err(InitError::DeploymentTargetNotSupported(
-                    app_state.0.config.deployment_target.clone(),
-                ));
             }
         }?;
         tracing::info!(

--- a/ai-gateway/src/router/service.rs
+++ b/ai-gateway/src/router/service.rs
@@ -45,12 +45,10 @@ impl Router {
         app_state: AppState,
     ) -> Result<Self, InitError> {
         let router_config = match &app_state.0.config.deployment_target {
-            DeploymentTarget::Cloud => {
-                return Err(InitError::DeploymentTargetNotSupported(
-                    app_state.0.config.deployment_target.clone(),
-                ));
-            }
-            DeploymentTarget::SelfHosted | DeploymentTarget::Sidecar => {
+            DeploymentTarget::Cloud | DeploymentTarget::Sidecar => {
+                // Note: Cloud will eventually get router configs from the
+                // database, but for not we are just allowing
+                // the cloud to be deployed to start dogfooding
                 let router_config = app_state
                     .0
                     .config


### PR DESCRIPTION
- there is no functional difference between the SelfHosted and Sidecar deployment target variants, so remove the self hosted one.
- Also remove errors so we can deploy with the DeploymentTarget::Cloud variant configured