### PR TITLE
Fix/anthropic stream errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "ai-gateway"
-version = "0.2.0-beta.1"
+version = "0.2.0-beta.2"
 dependencies = [
  "anthropic-ai-sdk",
  "async-openai",
@@ -3000,7 +3000,7 @@ dependencies = [
 
 [[package]]
 name = "mock-server"
-version = "0.2.0-beta.1"
+version = "0.2.0-beta.2"
 dependencies = [
  "ai-gateway",
  "tokio",
@@ -5025,7 +5025,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "telemetry"
-version = "0.2.0-beta.1"
+version = "0.2.0-beta.2"
 dependencies = [
  "http 1.3.1",
  "log-panics",
@@ -5970,7 +5970,7 @@ dependencies = [
 
 [[package]]
 name = "weighted-balance"
-version = "0.2.0-beta.1"
+version = "0.2.0-beta.2"
 dependencies = [
  "futures",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2024"
 authors = [ "Thomas Harmon <tom@helicone.ai>, Justin Torre <justin@helicone.ai>, Kavin Desi Valli <kavin@helicone.ai>, Charlie Wu <charlie@helicone.ai>", "Helicone Developers" ]
 license = "UNLICENSED"
 publish = false
-version = "0.2.0-beta.1"
+version = "0.2.0-beta.2"
 
 [profile.release]
 opt-level = 3

--- a/ai-gateway/config/local.yaml
+++ b/ai-gateway/config/local.yaml
@@ -1,5 +1,5 @@
 telemetry:
-  level: "info,llm_proxy=trace"
+  level: "info,ai_gateway=trace"
   exporter: both
 
 helicone-observability:
@@ -12,5 +12,5 @@ routers:
     load-balance:
       chat:
         strategy: latency
-        targets:
+        providers:
           - openai

--- a/ai-gateway/config/sidecar.yaml
+++ b/ai-gateway/config/sidecar.yaml
@@ -3,5 +3,5 @@ routers:
     load-balance:
       chat:
         strategy: latency
-        targets:
+        providers:
           - openai

--- a/ai-gateway/src/dispatcher/client.rs
+++ b/ai-gateway/src/dispatcher/client.rs
@@ -167,6 +167,7 @@ pub(super) fn sse_stream(mut event_source: EventSource) -> SSEStream {
                         if let Err(_e) = tx
                             .send(Err(InternalError::StreamError(Box::new(e))))
                         {
+                            tracing::trace!("rx dropped before stream ended");
                             // rx dropped
                             break;
                         }
@@ -180,6 +181,9 @@ pub(super) fn sse_stream(mut event_source: EventSource) -> SSEStream {
                             let data = Bytes::from(message.data);
 
                             if let Err(_e) = tx.send(Ok(data)) {
+                                tracing::trace!(
+                                    "rx dropped before stream ended"
+                                );
                                 // rx dropped
                                 break;
                             }

--- a/ai-gateway/src/dispatcher/service.rs
+++ b/ai-gateway/src/dispatcher/service.rs
@@ -333,7 +333,7 @@ impl Dispatcher {
                     let collect_future = body_reader.collect();
                     let (_response_body, tfft_duration) = tokio::join!(collect_future, tfft_future);
                     if let Ok(tfft_duration) = tfft_duration {
-                        tracing::trace!(tfft_duration = ?tfft_duration, "TFFT duration");
+                        tracing::trace!(tfft_duration = ?tfft_duration, "tfft_duration");
                         let attributes = [
                             KeyValue::new("provider", inference_provider.to_string()),
                             KeyValue::new("model", model),

--- a/ai-gateway/src/logger/service.rs
+++ b/ai-gateway/src/logger/service.rs
@@ -84,6 +84,7 @@ impl LoggerService {
             tracing::error!("Failed to get TFFT signal");
             Duration::from_secs(0)
         });
+        tracing::trace!(tfft_duration = ?tfft_duration, "tfft_duration");
         let req_body_len = self.request_body.len();
         let resp_body_len = response_body.len();
         let request_id = Uuid::new_v4();

--- a/ai-gateway/src/middleware/cache/service.rs
+++ b/ai-gateway/src/middleware/cache/service.rs
@@ -268,7 +268,6 @@ async fn handle_response_for_cache_miss<C: CacheManager>(
         .put(key, http_resp, policy)
         .await
         .map_err(InternalError::CacheError)?;
-    tracing::debug!("cached response");
 
     build_response(
         cached,

--- a/ai-gateway/src/types/provider.rs
+++ b/ai-gateway/src/types/provider.rs
@@ -164,6 +164,7 @@ impl ProviderKey {
         }
     }
 
+    #[must_use]
     pub fn from_env(provider: InferenceProvider) -> Option<Self> {
         if provider == InferenceProvider::Bedrock {
             if let (Ok(access_key), Ok(secret_key)) = (
@@ -181,10 +182,6 @@ impl ProviderKey {
             let provider_str = provider.to_string().to_uppercase();
             let env_var = format!("{provider_str}_API_KEY");
             if let Ok(key) = std::env::var(&env_var) {
-                tracing::trace!(
-                    provider = %provider,
-                    "Got provider key"
-                );
                 Some(ProviderKey::Secret(Secret::from(key)))
             } else {
                 None
@@ -215,17 +212,8 @@ impl ProviderKeys {
         for provider in providers {
             if provider == InferenceProvider::Ollama {
                 // ollama doesn't require an API key
-                tracing::debug!(
-                    provider = %provider,
-                    "from_env_inner ollama"
-                );
                 continue;
             }
-
-            tracing::debug!(
-                provider = %provider,
-                "from_env_inner"
-            );
             if let Some(key) = ProviderKey::from_env(provider) {
                 keys.insert(provider, key);
             }
@@ -251,7 +239,6 @@ impl ProviderKeys {
         let keys = providers_config
             .iter()
             .filter_map(|(&provider, _)| {
-                tracing::debug!(provider = %provider, "from_env_direct_proxy");
                 ProviderKey::from_env(provider).map(|key| (provider, key))
             })
             .collect();


### PR DESCRIPTION
- the `reqwest_eventstream::error::StreamEnd` encountered when using anthropic streams seems to be
  valid so we shouldn't increment metrics, log errors, etc.
- Properly increment health error metrics for malformed streams
- Remove some dev logging and make logs better
