### PR TITLE
feat: fly IO support

### DIFF
--- a/ai-gateway/config/sidecar.yaml
+++ b/ai-gateway/config/sidecar.yaml
@@ -1,3 +1,7 @@
+server:
+  address: 0.0.0.0
+  port: 8080
+
 routers:
   default:
     load-balance:

--- a/ai-gateway/config/sidecar.yaml
+++ b/ai-gateway/config/sidecar.yaml
@@ -1,7 +1,3 @@
-server:
-  address: 0.0.0.0
-  port: 8080
-
 routers:
   default:
     load-balance:

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,31 @@
+app = "helicone-ai-gateway"
+primary_region = "iad"
+
+[build]
+  image = "helicone/ai-gateway:main"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "off"
+  auto_start_machines = true
+  min_machines_running = 1
+
+[[vm]]
+  cpu_kind = "shared"
+  cpus = 1
+  memory = "512mb"
+
+[[http_service.checks]]
+  grace_period = "5s"
+  interval = "30s"
+  method = "GET"
+  timeout = "5s"
+  path = "/health"
+
+[experimental]
+cmd = ["/usr/local/bin/ai-gateway", "-c", "/app/config/config.yaml"]
+
+[[files]]
+  guest_path = "/app/config/config.yaml"
+  local_path = "ai-gateway/config/sidecar.yaml"

--- a/fly.toml
+++ b/fly.toml
@@ -28,4 +28,24 @@ cmd = ["/usr/local/bin/ai-gateway", "-c", "/app/config/config.yaml"]
 
 [[files]]
   guest_path = "/app/config/config.yaml"
-  local_path = "ai-gateway/config/sidecar.yaml"
+  raw_value = '''
+server:
+  address: 0.0.0.0
+  port: 8080
+
+routers:
+  default:
+    load-balance:
+      chat:
+        strategy: latency
+        providers:
+          - openai
+          - anthropic
+
+helicone-observability:
+  enable-auth: true
+'''
+
+# [[files]]
+#   guest_path = "/app/config/config.yaml"
+#   local_path = "ai-gateway/config/sidecar.yaml"


### PR DESCRIPTION
This pull request introduces a new `fly.toml` configuration file to set up deployment for the `helicone-ai-gateway` application on the Fly.io platform. The configuration specifies application settings, deployment regions, build details, HTTP service configuration, VM specifications, health checks, and experimental commands.

### Deployment Configuration:

* Added `fly.toml` file to configure the deployment of the `helicone-ai-gateway` application, specifying the app name (`helicone-ai-gateway`) and primary region (`iad`).

### Build and Service Settings:

* Defined the build image as `helicone/ai-gateway:main` and configured the HTTP service to listen on internal port 8080 with HTTPS enforced. Auto-start and auto-stop machine settings were also added, with a minimum of one machine running.

### VM Specifications:

* Configured VM settings to use shared CPUs, 1 CPU core, and 512 MB of memory.

### Health Checks:

* Added health checks for the HTTP service with a 5-second grace period, 30-second interval, 5-second timeout, and a `GET` request to the `/health` endpoint.

### Experimental and File Configurations:

* Added an experimental command to run the AI gateway with a specified configuration file. Included a file definition for the gateway