### PR TITLE
Docs: remove the "helix" name from everywhere

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Hi there!
 
-We're thrilled that you'd like to contribute to Helicone Helix.
+We're thrilled that you'd like to contribute to Helicone AI Gateway.
 
 Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
 

--- a/crates/mock-server/Cargo.toml
+++ b/crates/mock-server/Cargo.toml
@@ -5,7 +5,7 @@ authors.workspace = true
 license.workspace = true
 publish = false
 version.workspace = true
-description = "A standalone binary for running a mock server for the Helix Router 3rd party apis in order to enable load testing"
+description = "A standalone binary for running a mock server for the Helicone AI Gateway 3rd party apis in order to enable load testing"
 
 [dependencies]
 ai-gateway = { workspace = true, features = ["testing"] }

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 version = { workspace = true }
 description = "OpenTelemetry telemetry configuration and utilities for the LLM proxy router"
 authors.workspace = true
-homepage = "https://helix.helicone.ai"
+homepage = "https://docs.helicone.ai/ai-gateway/overview"
 
 [dependencies]
 http.workspace = true

--- a/crates/weighted-balance/Cargo.toml
+++ b/crates/weighted-balance/Cargo.toml
@@ -5,7 +5,7 @@ authors.workspace = true
 license.workspace = true
 version.workspace = true
 description = "Weighted load balancing algorithms for the LLM proxy router"
-homepage = "https://helix.helicone.ai"
+homepage = "https://docs.helicone.ai/ai-gateway/overview"
 publish = false
 
 [dependencies]


### PR DESCRIPTION
Found some "helix" remnants throughout the repo. 