### PR TITLE
feat: add redis for cache support

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -39,7 +39,7 @@ jobs:
       redis:
         image: redis:8.0.2-alpine
         ports:
-          - 6340:6340
+          - 6340:6379
     steps:
       - uses: actions/checkout@v4
       - name: Test

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -39,7 +39,7 @@ jobs:
       redis:
         image: redis:8.0.2-alpine
         ports:
-          - 6379:6379
+          - 6340:6340
     steps:
       - uses: actions/checkout@v4
       - name: Test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,7 @@ version = "0.2.0-beta.14"
 dependencies = [
  "anthropic-ai-sdk",
  "async-openai",
+ "async-trait",
  "aws-credential-types 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "aws-sdk-bedrockruntime",
  "aws-sigv4 1.3.3",
@@ -4093,6 +4094,7 @@ dependencies = [
  "itoa",
  "num-bigint",
  "percent-encoding",
+ "r2d2",
  "ryu",
  "sha1_smol",
  "socket2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "ai-gateway"
-version = "0.2.0-beta.14"
+version = "0.2.0-beta.15"
 dependencies = [
  "anthropic-ai-sdk",
  "async-openai",
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "mock-server"
-version = "0.2.0-beta.14"
+version = "0.2.0-beta.15"
 dependencies = [
  "ai-gateway",
  "serde_json",
@@ -5109,7 +5109,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "telemetry"
-version = "0.2.0-beta.14"
+version = "0.2.0-beta.15"
 dependencies = [
  "http 1.3.1",
  "log-panics",
@@ -6058,7 +6058,7 @@ dependencies = [
 
 [[package]]
 name = "weighted-balance"
-version = "0.2.0-beta.14"
+version = "0.2.0-beta.15"
 dependencies = [
  "futures",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2024"
 authors = [ "Thomas Harmon <tom@helicone.ai>, Justin Torre <justin@helicone.ai>, Kavin Desi Valli <kavin@helicone.ai>, Charlie Wu <charlie@helicone.ai>", "Helicone Developers" ]
 license = "Apache-2.0"
 publish = false
-version = "0.2.0-beta.14"
+version = "0.2.0-beta.15"
 
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ weighted-balance = { path = "./crates/weighted-balance" }
 anthropic-ai-sdk = { version = "0.2.25" }
 anyhow = "1.0.98"
 async-openai = { version = "0.28.4", git = "https://github.com/tomharmon/async-openai.git", branch = "task/add-serialize-for-api-error" }
+async-trait = "0.1.88"
 axum-core = "0.5.2"
 aws-sdk-bedrockruntime = { version = "1.92.0", git = "https://github.com/hcharlie1201/aws-sdk-rust.git" }
 aws-smithy-types = { version = "1.3.2", features = ["serde-serialize", "serde-deserialize"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ pin-project-lite = "0.2.16"
 pretty_assertions = "1.4.1"
 r2d2 = "0.8.10"
 rand = "0.9.1"
-redis = "0.27.6"
+redis = { version = "0.27.6", features = ["r2d2"] }
 regex = "1.11.1"
 reqwest = { version = "0.12.15", features = ["json", "stream", "multipart", "native-tls", "charset"], default-features = false }
 reqwest-eventsource = "0.6.0"

--- a/ai-gateway/Cargo.toml
+++ b/ai-gateway/Cargo.toml
@@ -100,6 +100,7 @@ pretty_assertions = { workspace = true }
 [features]
 default = []
 testing = ["dep:stubr", "dep:serial_test", "dep:workspace_root"]
+redis-testing = []
 
 [lints]
 workspace = true
@@ -151,6 +152,10 @@ required-features = ["testing"]
 [[test]]
 name = "cache"
 required-features = ["testing"]
+
+[[test]]
+name = "redis_cache"
+required-features = ["testing", "redis-testing"]
 
 [[test]]
 name = "health_check"

--- a/ai-gateway/Cargo.toml
+++ b/ai-gateway/Cargo.toml
@@ -56,7 +56,7 @@ opentelemetry-system-metrics = { workspace = true }
 pin-project-lite = { workspace = true }
 r2d2 = { workspace = true }
 rand = { workspace = true }
-redis = { workspace = true }
+redis = { workspace = true, features = ["r2d2"] }
 regex = { workspace = true }
 reqwest = { workspace = true }
 reqwest-eventsource = { workspace = true }
@@ -91,6 +91,7 @@ uuid = { workspace = true, features = ["serde", "v7"] }
 weighted-balance = { workspace = true }
 workspace_root = { workspace = true, optional = true }
 ts-rs = { workspace = true }
+async-trait = "0.1.88"
 
 [dev-dependencies]
 cargo-husky = { workspace = true, features = ["user-hooks"] }

--- a/ai-gateway/Cargo.toml
+++ b/ai-gateway/Cargo.toml
@@ -12,6 +12,7 @@ homepage = "https://docs.helicone.ai/ai-gateway"
 anthropic-ai-sdk = { workspace = true }
 sha2 = { workspace = true }
 async-openai = { workspace = true }
+async-trait = { workspace = true }
 axum-core = { workspace = true }
 axum-server = { workspace = true, features = ["tls-rustls"] }
 aws-sdk-bedrockruntime = { workspace = true }
@@ -91,7 +92,6 @@ uuid = { workspace = true, features = ["serde", "v7"] }
 weighted-balance = { workspace = true }
 workspace_root = { workspace = true, optional = true }
 ts-rs = { workspace = true }
-async-trait = "0.1.88"
 
 [dev-dependencies]
 cargo-husky = { workspace = true, features = ["user-hooks"] }

--- a/ai-gateway/src/app.rs
+++ b/ai-gateway/src/app.rs
@@ -207,7 +207,7 @@ impl App {
                     );
                 })?;
 
-        let cache_manager = setup_cache(&config, metrics.clone());
+        let cache_manager = setup_cache(&config, metrics.clone())?;
 
         let app_state = AppState(Arc::new(InnerAppState {
             config,
@@ -226,7 +226,7 @@ impl App {
             rate_limit_monitors: rate_limit_monitor,
             rate_limit_senders: RwLock::new(HashMap::default()),
             rate_limit_receivers: RwLock::new(HashMap::default()),
-            cache_manager: cache_manager?,
+            cache_manager,
         }));
 
         let otel_metrics_layer =

--- a/ai-gateway/src/app_state.rs
+++ b/ai-gateway/src/app_state.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use http_cache::MokaManager;
 use rustc_hash::FxHashMap as HashMap;
 use tokio::sync::{
     RwLock,
@@ -8,6 +7,7 @@ use tokio::sync::{
 };
 
 use crate::{
+    cache::InternalCacheManager,
     config::{
         Config, minio::Minio, rate_limit::RateLimiterConfig,
         response_headers::ResponseHeadersConfig, router::RouterConfig,
@@ -52,7 +52,7 @@ pub struct InnerAppState {
     pub control_plane_state: Arc<RwLock<ControlPlaneState>>,
     pub direct_proxy_api_keys: ProviderKeys,
     pub provider_keys: RwLock<HashMap<RouterId, ProviderKeys>>,
-    pub moka_manager: Option<MokaManager>,
+    pub cache_manager: Option<InternalCacheManager>,
     pub global_rate_limit: Option<Arc<RateLimiterConfig>>,
     pub router_rate_limits: RwLock<HashMap<RouterId, Arc<RateLimiterConfig>>>,
     /// Top level metrics which are exported to OpenTelemetry.

--- a/ai-gateway/src/app_state.rs
+++ b/ai-gateway/src/app_state.rs
@@ -7,7 +7,7 @@ use tokio::sync::{
 };
 
 use crate::{
-    cache::InternalCacheManager,
+    cache::CacheClient,
     config::{
         Config, minio::Minio, rate_limit::RateLimiterConfig,
         response_headers::ResponseHeadersConfig, router::RouterConfig,
@@ -52,7 +52,7 @@ pub struct InnerAppState {
     pub control_plane_state: Arc<RwLock<ControlPlaneState>>,
     pub direct_proxy_api_keys: ProviderKeys,
     pub provider_keys: RwLock<HashMap<RouterId, ProviderKeys>>,
-    pub cache_manager: Option<InternalCacheManager>,
+    pub cache_manager: Option<CacheClient>,
     pub global_rate_limit: Option<Arc<RateLimiterConfig>>,
     pub router_rate_limits: RwLock<HashMap<RouterId, Arc<RateLimiterConfig>>>,
     /// Top level metrics which are exported to OpenTelemetry.

--- a/ai-gateway/src/cache.rs
+++ b/ai-gateway/src/cache.rs
@@ -1,0 +1,101 @@
+use http_cache::{CacheManager, HttpResponse, MokaManager, Result};
+use http_cache_semantics::CachePolicy;
+use r2d2::Pool;
+use redis::{Client, Commands};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone)]
+pub enum InternalCacheManager {
+    Redis(RedisCacheManager),
+    Moka(MokaManager),
+}
+
+#[derive(Debug, Clone)]
+pub struct RedisCacheManager {
+    pool: Pool<Client>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Store {
+    response: HttpResponse,
+    policy: CachePolicy,
+}
+
+impl RedisCacheManager {
+    pub fn new(url: String) -> Self {
+        let client = Client::open(url).unwrap();
+        let pool = Pool::builder().build(client).unwrap();
+        Self { pool }
+    }
+}
+
+#[async_trait::async_trait]
+impl CacheManager for RedisCacheManager {
+    async fn get(
+        &self,
+        cache_key: &str,
+    ) -> Result<Option<(HttpResponse, CachePolicy)>> {
+        let mut conn = self.pool.get().unwrap();
+        let value: String = conn.get(cache_key)?;
+        let store: Store = serde_json::from_str(&value)?;
+        Ok(Some((store.response, store.policy)))
+    }
+
+    async fn put(
+        &self,
+        cache_key: String,
+        response: HttpResponse,
+        policy: CachePolicy,
+    ) -> Result<HttpResponse> {
+        let mut conn = self.pool.get().unwrap();
+        let store = Store {
+            response: response.clone(),
+            policy,
+        };
+        let serialized = serde_json::to_string(&store).unwrap();
+        let _: () = conn.set(cache_key, serialized)?;
+        Ok(response)
+    }
+
+    async fn delete(&self, cache_key: &str) -> Result<()> {
+        let mut conn = self.pool.get().unwrap();
+        let _: () = conn.del(cache_key)?;
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl CacheManager for InternalCacheManager {
+    async fn get(
+        &self,
+        cache_key: &str,
+    ) -> Result<Option<(HttpResponse, CachePolicy)>> {
+        match self {
+            InternalCacheManager::Redis(redis) => redis.get(cache_key).await,
+            InternalCacheManager::Moka(moka) => moka.get(cache_key).await,
+        }
+    }
+
+    async fn put(
+        &self,
+        cache_key: String,
+        response: HttpResponse,
+        policy: CachePolicy,
+    ) -> Result<HttpResponse> {
+        match self {
+            InternalCacheManager::Redis(redis) => {
+                redis.put(cache_key, response, policy).await
+            }
+            InternalCacheManager::Moka(moka) => {
+                moka.put(cache_key, response, policy).await
+            }
+        }
+    }
+
+    async fn delete(&self, cache_key: &str) -> Result<()> {
+        match self {
+            InternalCacheManager::Redis(redis) => redis.delete(cache_key).await,
+            InternalCacheManager::Moka(moka) => moka.delete(cache_key).await,
+        }
+    }
+}

--- a/ai-gateway/src/cache.rs
+++ b/ai-gateway/src/cache.rs
@@ -5,7 +5,7 @@ use redis::{Client, Commands};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone)]
-pub enum InternalCacheManager {
+pub enum CacheClient {
     Redis(RedisCacheManager),
     Moka(MokaManager),
 }
@@ -66,14 +66,14 @@ impl CacheManager for RedisCacheManager {
 }
 
 #[async_trait::async_trait]
-impl CacheManager for InternalCacheManager {
+impl CacheManager for CacheClient {
     async fn get(
         &self,
         cache_key: &str,
     ) -> Result<Option<(HttpResponse, CachePolicy)>> {
         match self {
-            InternalCacheManager::Redis(redis) => redis.get(cache_key).await,
-            InternalCacheManager::Moka(moka) => moka.get(cache_key).await,
+            CacheClient::Redis(redis) => redis.get(cache_key).await,
+            CacheClient::Moka(moka) => moka.get(cache_key).await,
         }
     }
 
@@ -84,10 +84,10 @@ impl CacheManager for InternalCacheManager {
         policy: CachePolicy,
     ) -> Result<HttpResponse> {
         match self {
-            InternalCacheManager::Redis(redis) => {
+            CacheClient::Redis(redis) => {
                 redis.put(cache_key, response, policy).await
             }
-            InternalCacheManager::Moka(moka) => {
+            CacheClient::Moka(moka) => {
                 moka.put(cache_key, response, policy).await
             }
         }
@@ -95,8 +95,8 @@ impl CacheManager for InternalCacheManager {
 
     async fn delete(&self, cache_key: &str) -> Result<()> {
         match self {
-            InternalCacheManager::Redis(redis) => redis.delete(cache_key).await,
-            InternalCacheManager::Moka(moka) => moka.delete(cache_key).await,
+            CacheClient::Redis(redis) => redis.delete(cache_key).await,
+            CacheClient::Moka(moka) => moka.delete(cache_key).await,
         }
     }
 }

--- a/ai-gateway/src/cache.rs
+++ b/ai-gateway/src/cache.rs
@@ -22,6 +22,7 @@ struct Store {
 }
 
 impl RedisCacheManager {
+    #[must_use]
     pub fn new(url: String) -> Self {
         let client = Client::open(url).unwrap();
         let pool = Pool::builder().build(client).unwrap();

--- a/ai-gateway/src/cache.rs
+++ b/ai-gateway/src/cache.rs
@@ -4,6 +4,8 @@ use r2d2::Pool;
 use redis::{Client, Commands};
 use serde::{Deserialize, Serialize};
 
+use crate::error::init::InitError;
+
 #[derive(Debug, Clone)]
 pub enum CacheClient {
     Redis(RedisCacheManager),
@@ -22,11 +24,10 @@ struct Store {
 }
 
 impl RedisCacheManager {
-    #[must_use]
-    pub fn new(url: String) -> Self {
-        let client = Client::open(url).unwrap();
-        let pool = Pool::builder().build(client).unwrap();
-        Self { pool }
+    pub fn new(url: url::Url) -> std::result::Result<Self, InitError> {
+        let client = Client::open(url)?;
+        let pool = Pool::builder().build(client)?;
+        Ok(Self { pool })
     }
 }
 
@@ -36,7 +37,7 @@ impl CacheManager for RedisCacheManager {
         &self,
         cache_key: &str,
     ) -> Result<Option<(HttpResponse, CachePolicy)>> {
-        let mut conn = self.pool.get().unwrap();
+        let mut conn = self.pool.get()?;
         let value: String = conn.get(cache_key)?;
         let store: Store = serde_json::from_str(&value)?;
         Ok(Some((store.response, store.policy)))
@@ -48,18 +49,18 @@ impl CacheManager for RedisCacheManager {
         response: HttpResponse,
         policy: CachePolicy,
     ) -> Result<HttpResponse> {
-        let mut conn = self.pool.get().unwrap();
+        let mut conn = self.pool.get()?;
         let store = Store {
             response: response.clone(),
             policy,
         };
-        let serialized = serde_json::to_string(&store).unwrap();
+        let serialized = serde_json::to_string(&store)?;
         let _: () = conn.set(cache_key, serialized)?;
         Ok(response)
     }
 
     async fn delete(&self, cache_key: &str) -> Result<()> {
-        let mut conn = self.pool.get().unwrap();
+        let mut conn = self.pool.get()?;
         let _: () = conn.del(cache_key)?;
         Ok(())
     }

--- a/ai-gateway/src/config/cache.rs
+++ b/ai-gateway/src/config/cache.rs
@@ -33,7 +33,7 @@ impl crate::tests::TestDefault for CacheConfig {
 pub enum CacheStore {
     Redis {
         #[serde(rename = "host-url", default = "default_host_url")]
-        host_url: String,
+        host_url: url::Url,
     },
     InMemory {
         // apparently container-level `rename_all` for enums doesn't
@@ -61,6 +61,6 @@ fn default_buckets() -> u8 {
     1
 }
 
-fn default_host_url() -> String {
-    "redis://localhost:6379".to_string()
+fn default_host_url() -> url::Url {
+    "redis://localhost:6379".parse().unwrap()
 }

--- a/ai-gateway/src/config/cache.rs
+++ b/ai-gateway/src/config/cache.rs
@@ -28,9 +28,13 @@ impl crate::tests::TestDefault for CacheConfig {
     }
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, Serialize, Eq, PartialEq, Hash)]
-#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq, Hash)]
+#[serde(rename_all = "kebab-case", tag = "type")]
 pub enum CacheStore {
+    Redis {
+        #[serde(rename = "host-url", default = "default_host_url")]
+        host_url: String,
+    },
     InMemory {
         // apparently container-level `rename_all` for enums doesn't
         // apply to the fields of the enum, so we need to rename the field
@@ -38,22 +42,6 @@ pub enum CacheStore {
         #[serde(rename = "max-size", default = "default_max_size")]
         max_size: usize,
     },
-}
-
-impl CacheStore {
-    #[must_use]
-    pub fn merge(&self, other: &Self) -> Self {
-        match (self, other) {
-            (
-                Self::InMemory { max_size },
-                Self::InMemory {
-                    max_size: other_max_size,
-                },
-            ) => Self::InMemory {
-                max_size: *max_size.max(other_max_size),
-            },
-        }
-    }
 }
 
 impl Default for CacheStore {
@@ -71,4 +59,8 @@ fn default_max_size() -> usize {
 
 fn default_buckets() -> u8 {
     1
+}
+
+fn default_host_url() -> String {
+    "redis://localhost:6379".to_string()
 }

--- a/ai-gateway/src/config/cache.rs
+++ b/ai-gateway/src/config/cache.rs
@@ -62,5 +62,5 @@ fn default_buckets() -> u8 {
 }
 
 fn default_host_url() -> url::Url {
-    "redis://localhost:6379".parse().unwrap()
+    "redis://localhost:6340".parse().unwrap()
 }

--- a/ai-gateway/src/lib.rs
+++ b/ai-gateway/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod app;
 pub mod app_state;
 pub(crate) mod balancer;
+pub mod cache;
 pub mod cli;
 pub mod config;
 pub mod control_plane;

--- a/ai-gateway/src/middleware/cache/service.rs
+++ b/ai-gateway/src/middleware/cache/service.rs
@@ -64,9 +64,6 @@ impl CacheContext {
     /// Merge two cache configs. `Other` takes precedence over `Self`.
     #[must_use]
     pub fn merge(&self, other: &Self) -> Self {
-        println!("in service");
-        println!("self: {:?}", self);
-        println!("other: {:?}", other);
         let enabled = if let Some(other_explicitly_set) = other.enabled {
             // if other is set, just use that value (so req headers can disable
             // whether caching is enabled or not per request)

--- a/ai-gateway/src/middleware/cache/service.rs
+++ b/ai-gateway/src/middleware/cache/service.rs
@@ -23,7 +23,7 @@ use url::Url;
 
 use crate::{
     app_state::AppState,
-    cache::InternalCacheManager,
+    cache::CacheClient,
     config::{
         cache::{CacheConfig, DEFAULT_BUCKETS, MAX_BUCKET_SIZE},
         router::RouterConfig,
@@ -89,7 +89,7 @@ impl CacheContext {
 #[derive(Debug, Clone)]
 pub struct CacheLayer {
     app_state: AppState,
-    backend: InternalCacheManager,
+    backend: CacheClient,
     context: Arc<CacheContext>,
 }
 
@@ -158,7 +158,7 @@ impl<S> tower::Layer<S> for CacheLayer {
 pub struct CacheService<S> {
     inner: S,
     app_state: AppState,
-    backend: InternalCacheManager,
+    backend: CacheClient,
     context: Arc<CacheContext>,
 }
 
@@ -207,7 +207,7 @@ where
 #[allow(clippy::too_many_lines)]
 async fn check_cache(
     app_state: AppState,
-    cache: &InternalCacheManager,
+    cache: &CacheClient,
     key: &str,
     req: Request,
     bucket: u8,
@@ -347,7 +347,7 @@ fn bucket_header_value(bucket: u8) -> HeaderValue {
 }
 
 async fn handle_response_for_cache_miss(
-    cache: &InternalCacheManager,
+    cache: &CacheClient,
     ctx: &CacheContext,
     key: String,
     req: Request,
@@ -407,7 +407,7 @@ async fn make_request<S>(
     inner: &mut S,
     app_state: &AppState,
     mut req: Request,
-    cache: &InternalCacheManager,
+    cache: &CacheClient,
     ctx: CacheContext,
 ) -> Result<Response, ApiError>
 where

--- a/ai-gateway/tests/redis_cache.rs
+++ b/ai-gateway/tests/redis_cache.rs
@@ -1,0 +1,437 @@
+use std::{collections::HashMap, time::Duration};
+
+use ai_gateway::{
+    config::{Config, cache::CacheStore},
+    tests::{TestDefault, harness::Harness, mock::MockArgs},
+};
+use http::{Method, Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::json;
+use tower::Service;
+
+/// Helper function to make a POST request to the specified URL
+fn make_request(
+    url: &str,
+    cache_control: Option<(&str, &str)>,
+) -> Request<axum_core::body::Body> {
+    let request_body = serde_json::to_vec(&json!({
+        "model": "openai/gpt-4o-mini",
+        "messages": [
+            {
+                "role": "user",
+                "content": "Hello, world!"
+            }
+        ]
+    }))
+    .unwrap();
+
+    let mut builder = Request::builder()
+        .method(Method::POST)
+        .uri(url)
+        .header("content-type", "application/json")
+        .header("authorization", "Bearer sk-helicone-test-key");
+
+    if let Some((name, value)) = cache_control {
+        builder = builder.header(name, value);
+    }
+
+    builder
+        .body(axum_core::body::Body::from(request_body))
+        .unwrap()
+}
+
+/// Test that requests are cached when enabled globally via config.
+/// This should check that requests on any of the three possible URLs
+/// (`/ai/chat/completions`, `/openai/v1/chat/completions`,
+/// `/router/default/chat/completions`) are cached. Start with the default
+/// router and then expand the test cases.
+///
+/// In order to assert that the request is cached, we need to make sure that
+/// the request is made twice. The first request will be a cache miss accoridng
+/// to the `helicone-cache` response header and the second request should be a
+/// hit according to the `helicone-cache` response header.
+#[tokio::test]
+#[serial_test::serial(default_mock)]
+async fn cache_enabled_globally() {
+    let mut config = Config::test_default();
+
+    config.cache_store = CacheStore::Redis {
+        host_url: "redis://localhost:6340".parse().unwrap(),
+    };
+
+    let mock_args = MockArgs::builder()
+        .stubs(HashMap::from([
+            ("success:openai:chat_completion_cacheable", 3.into()),
+            ("success:minio:upload_request", 6.into()),
+            ("success:jawn:sign_s3_url", 6.into()),
+            ("success:jawn:log_request", 6.into()),
+        ]))
+        .build();
+
+    let mut harness = Harness::builder()
+        .with_config(config)
+        .with_mock_args(mock_args)
+        .with_mock_auth()
+        .build()
+        .await;
+
+    // First request - should be a cache miss
+    let request = make_request(
+        "http://router.helicone.com/router/default/chat/completions",
+        Some(("cache-control", "max-age=3600")),
+    );
+    let response = harness.call(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get("helicone-cache").unwrap(),
+        "MISS",
+        "First request should be a cache miss"
+    );
+    let _response_body = response.into_body().collect().await.unwrap();
+
+    // Second request - should be a cache hit
+    let request = make_request(
+        "http://router.helicone.com/router/default/chat/completions",
+        Some(("cache-control", "max-age=3600")),
+    );
+    let response = harness.call(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get("helicone-cache").unwrap(),
+        "HIT",
+        "Second request should be a cache hit"
+    );
+    let _response_body = response.into_body().collect().await.unwrap();
+
+    // Test passthrough endpoints
+    // Test /openai/v1/chat/completions - first request should be a cache miss
+    // since we have a different path (includes the prefix of the provider)
+    let request = make_request(
+        "http://router.helicone.com/openai/v1/chat/completions",
+        Some(("cache-control", "max-age=3600")),
+    );
+    let response = harness.call(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get("helicone-cache").unwrap(),
+        "MISS",
+        "First request to /openai endpoint should be a cache miss"
+    );
+    let _response_body = response.into_body().collect().await.unwrap();
+
+    let request = make_request(
+        "http://router.helicone.com/openai/v1/chat/completions",
+        Some(("cache-control", "max-age=3600")),
+    );
+    let response = harness.call(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get("helicone-cache").unwrap(),
+        "HIT",
+        "Second request to /openai endpoint should be a cache hit"
+    );
+    let _response_body = response.into_body().collect().await.unwrap();
+
+    // test unified api
+    // Test /ai/chat/completions
+    let request = make_request(
+        "http://router.helicone.com/ai/chat/completions",
+        Some(("cache-control", "max-age=3600")),
+    );
+    let response = harness.call(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get("helicone-cache").unwrap(),
+        "MISS",
+        "First request to /ai endpoint should be a cache miss"
+    );
+    let _response_body = response.into_body().collect().await.unwrap();
+
+    let request = make_request(
+        "http://router.helicone.com/ai/chat/completions",
+        Some(("cache-control", "max-age=3600")),
+    );
+    let response = harness.call(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get("helicone-cache").unwrap(),
+        "HIT",
+        "Second request to /ai endpoint should be a cache hit"
+    );
+    let _response_body = response.into_body().collect().await.unwrap();
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+}
+
+/// Test that requests are not cached when disabled globally via config.
+/// This should check that requests on any of the three possible URLs
+/// (`/ai/chat/completions`, `/openai/v1/chat/completions`,
+/// `/router/default/chat/completions`) are NOT cached. Start with the
+/// default router and then expand the test cases.
+///
+/// In order to assert that the request is not cached, we need to
+/// sure the `helicone-cache` response header is never present
+#[tokio::test]
+#[serial_test::serial(default_mock)]
+async fn cache_disabled_globally() {
+    let mut config = Config::test_default();
+    config.helicone.authentication = false;
+    // Ensure cache is NOT set globally (None by default)
+    config.global.cache = None;
+
+    let mock_args = MockArgs::builder()
+        .stubs(HashMap::from([
+            ("success:openai:chat_completion", 6.into()), // Multiple requests, all should hit the backend
+            ("success:minio:upload_request", 0.into()),
+            ("success:jawn:log_request", 0.into()),
+        ]))
+        .build();
+
+    let mut harness = Harness::builder()
+        .with_config(config)
+        .with_mock_args(mock_args)
+        .build()
+        .await;
+
+    // Test multiple requests to ensure cache header is never present
+
+    // Test default router endpoint
+    // First request - should not have cache header
+    let request = make_request(
+        "http://router.helicone.com/router/default/chat/completions",
+        Some(("cache-control", "max-age=3600")),
+    );
+    let response = harness.call(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        response.headers().get("helicone-cache").is_none(),
+        "Cache header should not be present when cache is disabled"
+    );
+
+    // Second request - should still not have cache header
+    let request = make_request(
+        "http://router.helicone.com/router/default/chat/completions",
+        Some(("cache-control", "max-age=3600")),
+    );
+    let response = harness.call(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        response.headers().get("helicone-cache").is_none(),
+        "Cache header should not be present on second request when cache is \
+         disabled"
+    );
+
+    // Test passthrough endpoints
+    // Test /openai/v1/chat/completions
+    let request = make_request(
+        "http://router.helicone.com/openai/v1/chat/completions",
+        Some(("cache-control", "max-age=3600")),
+    );
+    let response = harness.call(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        response.headers().get("helicone-cache").is_none(),
+        "Cache header should not be present on /openai endpoint when cache is \
+         disabled"
+    );
+
+    let request = make_request(
+        "http://router.helicone.com/openai/v1/chat/completions",
+        Some(("cache-control", "max-age=3600")),
+    );
+    let response = harness.call(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        response.headers().get("helicone-cache").is_none(),
+        "Cache header should still not be present on second request to \
+         /openai endpoint"
+    );
+
+    // Test unified api
+    // Test /ai/chat/completions
+    let request = make_request(
+        "http://router.helicone.com/ai/chat/completions",
+        Some(("cache-control", "max-age=3600")),
+    );
+    let response = harness.call(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        response.headers().get("helicone-cache").is_none(),
+        "Cache header should not be present on /ai endpoint when cache is \
+         disabled"
+    );
+
+    let request = make_request(
+        "http://router.helicone.com/ai/chat/completions",
+        Some(("cache-control", "max-age=3600")),
+    );
+    let response = harness.call(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        response.headers().get("helicone-cache").is_none(),
+        "Cache header should still not be present on second request to /ai \
+         endpoint"
+    );
+}
+
+/// Test that requests are cached when enabled per router via config.
+/// This should check that requests on any of the three possible URLs
+/// (`/ai/chat/completions`, `/openai/v1/chat/completions`,
+/// `/router/default/chat/completions`) are cached. Start with the default
+/// router and then expand the test cases.
+///
+/// In order to assert that the request is cached, we need to
+/// sure the `helicone-cache` response header is present when expected.
+///
+/// Also, we need to make sure that if a request is cached for one router,
+/// it is not cached for another router, i.e. that they are independent and
+/// isolated caches.
+#[tokio::test]
+#[serial_test::serial(default_mock)]
+async fn cache_enabled_per_router() {
+    use ai_gateway::{
+        config::{
+            cache::CacheConfig,
+            router::{RouterConfig, RouterConfigs},
+        },
+        types::router::RouterId,
+    };
+    use compact_str::CompactString;
+
+    let mut config = Config::test_default();
+    // Disable auth for this test since we're testing basic passthrough
+    // functionality
+    config.helicone.authentication = false;
+    config.global.cache = None;
+
+    // Create multiple routers with different cache configurations
+    let router_with_cache_id = RouterId::Named(CompactString::from("cached"));
+    let router_without_cache_id =
+        RouterId::Named(CompactString::from("uncached"));
+
+    config.routers = RouterConfigs::new(HashMap::from([
+        (
+            router_with_cache_id.clone(),
+            RouterConfig {
+                cache: Some(CacheConfig {
+                    directive: None,
+                    buckets: 1,
+                    seed: Some("router-cached-seed".to_string()),
+                }),
+                load_balance:
+                    ai_gateway::config::balance::BalanceConfig::openai_chat(),
+                ..Default::default()
+            },
+        ),
+        (
+            router_without_cache_id.clone(),
+            RouterConfig {
+                cache: None, // No cache for this router
+                load_balance:
+                    ai_gateway::config::balance::BalanceConfig::openai_chat(),
+                ..Default::default()
+            },
+        ),
+        (
+            RouterId::Default,
+            RouterConfig {
+                cache: None, // Default router also has no cache
+                load_balance:
+                    ai_gateway::config::balance::BalanceConfig::openai_chat(),
+                ..Default::default()
+            },
+        ),
+    ]));
+
+    let mock_args = MockArgs::builder()
+        .stubs(HashMap::from([
+            ("success:openai:chat_completion_cacheable", 5.into()),
+            ("success:minio:upload_request", 0.into()),
+            ("success:jawn:log_request", 0.into()),
+        ]))
+        .build();
+
+    let mut harness = Harness::builder()
+        .with_config(config)
+        .with_mock_args(mock_args)
+        .build()
+        .await;
+
+    // Test 1: Router with cache enabled
+    // First request - should be a cache miss
+    let request = make_request(
+        "http://router.helicone.com/router/cached/chat/completions",
+        Some(("cache-control", "max-age=3600")),
+    );
+    let response = harness.call(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get("helicone-cache").unwrap(),
+        "MISS",
+        "First request should be a cache miss"
+    );
+
+    // Second request to same router - should be a cache hit
+    let request = make_request(
+        "http://router.helicone.com/router/cached/chat/completions",
+        Some(("cache-control", "max-age=3600")),
+    );
+    let response = harness.call(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get("helicone-cache").unwrap(),
+        "HIT",
+        "Second request should be a cache hit"
+    );
+
+    // Test 2: Router without cache
+    // Both requests should not have cache headers
+    let request = make_request(
+        "http://router.helicone.com/router/uncached/chat/completions",
+        Some(("cache-control", "max-age=3600")),
+    );
+    let response = harness.call(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        response.headers().get("helicone-cache").is_none(),
+        "Cache header should not be present when cache is disabled"
+    );
+
+    // Second request to uncached router
+    let request = make_request(
+        "http://router.helicone.com/router/uncached/chat/completions",
+        Some(("cache-control", "max-age=3600")),
+    );
+    let response = harness.call(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        response.headers().get("helicone-cache").is_none(),
+        "Cache header should not be present on second request when cache is \
+         disabled"
+    );
+
+    // Test 3: Default router (no cache)
+    let request = make_request(
+        "http://router.helicone.com/router/default/chat/completions",
+        Some(("cache-control", "max-age=3600")),
+    );
+    let response = harness.call(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        response.headers().get("helicone-cache").is_none(),
+        "Cache header should not be present on default router when cache is \
+         not configured"
+    );
+
+    let request = make_request(
+        "http://router.helicone.com/router/default/chat/completions",
+        Some(("cache-control", "max-age=3600")),
+    );
+    let response = harness.call(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        response.headers().get("helicone-cache").is_none(),
+        "Cache header should still not be present on second request to \
+         default router"
+    );
+}


### PR DESCRIPTION
Added the ability to configure the Helicone Router to use Redis as a cache backend instead of the default in-memory cache.

## Changes to Configuration

`cache-store` can be the following now:

1. in-memory

```
cache-store:
    type: "in-memory"
    max-size: 268435456
```

2. Redis

```
cache-store:
    type: "redis"
    host-url: "redis://localhost:6379"
```

`max-size` and `host-url` can be exempted and take the default values
