### PR TITLE
fix: misleading err log when observ. disabled

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,7 @@
 [alias]
 ci-clippy = "clippy --all-features -- -D warnings"
-int-test = "t --tests --all-features"
+int-test = "t --tests -F testing"
+all-int-test = "t --tests --all-features"
 rl = "run -- -c ./ai-gateway/config/local.yaml"
 rlt = "run --release -- -c ./ai-gateway/config/load-test.yaml"
 


### PR DESCRIPTION
this commit fixes a misleading error log, `BodyReader dropped before stream ended`, when `helicone.observability` was disabled, for cache hits.

The reason for this log was that with observability disabled, we would create a channel that sends response body chunks to a receiver, which would normally be used for logging, however when disabled it gets harmlessly dropped.

Instead, what we do now is the same approach to fixing this as we do in the dispatcher service for cache misses: spawn a tokio task anyway, polling it to completion. this also has the benefit of us being able to record the "tfft" metric in this scenario

the extra background task may seem wasteful but given the stream design of the gateway is not an issue for memory or cpu usage.