### PR TITLE
fix: propagate errors from streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "ai-gateway"
-version = "0.2.0-beta.16"
+version = "0.2.0-beta.17"
 dependencies = [
  "anthropic-ai-sdk",
  "async-openai",
@@ -3192,7 +3192,7 @@ dependencies = [
 
 [[package]]
 name = "mock-server"
-version = "0.2.0-beta.16"
+version = "0.2.0-beta.17"
 dependencies = [
  "ai-gateway",
  "axum",
@@ -5546,7 +5546,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "telemetry"
-version = "0.2.0-beta.16"
+version = "0.2.0-beta.17"
 dependencies = [
  "http 1.3.1",
  "log-panics",
@@ -6522,7 +6522,7 @@ dependencies = [
 
 [[package]]
 name = "weighted-balance"
-version = "0.2.0-beta.16"
+version = "0.2.0-beta.17"
 dependencies = [
  "futures",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2024"
 authors = [ "Thomas Harmon <tom@helicone.ai>, Justin Torre <justin@helicone.ai>, Kavin Desi Valli <kavin@helicone.ai>, Charlie Wu <charlie@helicone.ai>", "Helicone Developers" ]
 license = "Apache-2.0"
 publish = false
-version = "0.2.0-beta.16"
+version = "0.2.0-beta.17"
 
 
 [profile.release]

--- a/ai-gateway/src/control_plane/types.rs
+++ b/ai-gateway/src/control_plane/types.rs
@@ -149,7 +149,8 @@ mod tests {
     use super::*;
 
     #[test]
-    #[ignore]
+    #[ignore = "run explicitly with `cargo test export_types` when you want to \
+                update the bindings"]
     fn export_types() {
         fn generate_exports(dir: &Path) -> Option<Vec<String>> {
             let mut exports: Vec<String> = fs::read_dir(dir)

--- a/ai-gateway/src/control_plane/websocket.rs
+++ b/ai-gateway/src/control_plane/websocket.rs
@@ -287,9 +287,7 @@ mod tests {
             helicone_config,
         );
         let result = timeout(Duration::from_secs(1), connect_fut).await;
-        let result = if let Ok(r) = result {
-            r
-        } else {
+        let Ok(result) = result else {
             println!("timed out connecting to control plane, passing test");
             return;
         };

--- a/ai-gateway/src/discover/monitor/metrics.rs
+++ b/ai-gateway/src/discover/monitor/metrics.rs
@@ -80,8 +80,8 @@ impl EndpointMetrics {
             }
             reqwest_eventsource::Error::InvalidStatusCode(status_code, ..) => {
                 if status_code.is_server_error() {
+                    tracing::error!(status_code = %status_code, "got upstream server error in stream");
                     self.incr_remote_internal_error_count();
-                    tracing::error!(status_code = %status_code, "received error response in stream");
                 } else if status_code.is_client_error() {
                     tracing::debug!(status_code = %status_code, "got upstream client error in stream");
                 }

--- a/ai-gateway/src/dispatcher/client.rs
+++ b/ai-gateway/src/dispatcher/client.rs
@@ -53,18 +53,19 @@ pub enum Client {
 }
 
 impl Client {
-    pub(crate) fn sse_stream<B>(
+    pub(crate) async fn sse_stream<B>(
         request_builder: RequestBuilder,
         body: B,
-    ) -> Result<SSEStream, InternalError>
+    ) -> Result<SSEStream, ApiError>
     where
         B: Into<reqwest::Body>,
     {
         let event_source = request_builder
             .body(body)
             .eventsource()
-            .map_err(|e| InternalError::RequestBodyError(Box::new(e)))?;
-        Ok(sse_stream(event_source))
+            .map_err(|_e| InternalError::Internal)?;
+        let stream = sse_stream(event_source).await?;
+        Ok(stream)
     }
 
     fn new_inner(
@@ -157,8 +158,27 @@ impl AsRef<reqwest::Client> for Client {
 
 /// Request which responds with SSE.
 /// [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format)
-pub(super) fn sse_stream(mut event_source: EventSource) -> SSEStream {
+pub(super) async fn sse_stream(
+    mut event_source: EventSource,
+) -> Result<SSEStream, Box<reqwest_eventsource::Error>> {
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    // we want to await the first event so that we can propagate errors
+    match event_source.next().await {
+        Some(Ok(event)) => match event {
+            Event::Message(message) if message.data != "[DONE]" => {
+                let data = Bytes::from(message.data);
+
+                if let Err(_e) = tx.send(Ok(data)) {
+                    tracing::trace!("rx dropped before stream ended");
+                }
+            }
+            _ => {}
+        },
+        Some(Err(e)) => {
+            return Err(Box::new(e));
+        }
+        None => {}
+    }
 
     tokio::spawn(
         async move {
@@ -172,20 +192,10 @@ pub(super) fn sse_stream(mut event_source: EventSource) -> SSEStream {
                             break;
                         }
 
-                        cfg_if::cfg_if! {
-                            if #[cfg(debug_assertions)] {
-                                if let Err(e) = debug_stream_error(tx.clone(), e).await {
-                                    tracing::error!(error = %e, "rx dropped before stream ended");
-                                    break;
-                                }
-                            } else {
-                                if let Err(e) = tx.send(Err(InternalError::StreamError(Box::new(e)))) {
-                                    tracing::error!(error = %e, "rx dropped before stream ended");
-                                    break;
-                                }
-                            }
+                        if let Err(e) = handle_stream_error(tx.clone(), e).await {
+                            tracing::error!(error = %e, "failed to handle stream error");
+                            break;
                         }
-
                     }
                     Ok(event) => match event {
                         Event::Message(message) => {
@@ -196,7 +206,6 @@ pub(super) fn sse_stream(mut event_source: EventSource) -> SSEStream {
                             let data = Bytes::from(message.data);
 
                             if let Err(_e) = tx.send(Ok(data)) {
-                                // rx dropped
                                 tracing::trace!(
                                     "rx dropped before stream ended"
                                 );
@@ -213,47 +222,47 @@ pub(super) fn sse_stream(mut event_source: EventSource) -> SSEStream {
         .instrument(info_span!("sse_stream")),
     );
 
-    Box::pin(tokio_stream::wrappers::UnboundedReceiverStream::new(rx))
+    Ok(Box::pin(
+        tokio_stream::wrappers::UnboundedReceiverStream::new(rx),
+    ))
 }
 
-async fn debug_stream_error(
-    tx: tokio::sync::mpsc::UnboundedSender<Result<Bytes, InternalError>>,
+async fn handle_stream_error(
+    tx: tokio::sync::mpsc::UnboundedSender<Result<Bytes, ApiError>>,
     error: reqwest_eventsource::Error,
-) -> Result<(), tokio::sync::mpsc::error::SendError<Result<Bytes, InternalError>>>
-{
+) -> Result<(), InternalError> {
     match error {
         reqwest_eventsource::Error::InvalidStatusCode(
             status_code,
             response,
         ) => {
             let http_resp = http::Response::from(response);
-            let (parts, body) = http_resp.into_parts();
-            let Ok(body) = body.collect().await else {
-                tracing::error!("failed to collect body in stream");
-                // silence the error
-                return Ok(());
-            };
-            let body = body.to_bytes();
-            let text = String::from_utf8_lossy(&body);
-            tracing::debug!(status_code = %status_code, body = %text, "received error response in stream");
-            let stream = futures::stream::once(futures::future::ok::<
-                _,
-                InternalError,
-            >(body));
-            let new_body = reqwest::Body::wrap_stream(stream);
-            let new_response = http::Response::from_parts(parts, new_body);
-            let new_response = reqwest::Response::from(new_response);
+            let (_parts, body) = http_resp.into_parts();
+            let body = body.collect().await?.to_bytes();
 
-            let e = reqwest_eventsource::Error::InvalidStatusCode(
-                status_code,
-                new_response,
-            );
-            tx.send(Err(InternalError::StreamError(Box::new(e))))?;
+            cfg_if::cfg_if! {
+                // this is compiled out in release builds
+                if #[cfg(debug_assertions)] {
+                    let text = String::from_utf8_lossy(&body);
+                    tracing::debug!(status_code = %status_code, body = %text, "received error response in stream");
+                } else {
+                    if status_code.is_server_error() {
+                        tracing::error!(status_code = %status_code, "received server error in stream");
+                    } else if status_code.is_client_error() {
+                        tracing::debug!(status_code = %status_code, "received client error in stream");
+                    }
+                }
+            }
+
+            if let Err(e) = tx.send(Ok(body)) {
+                tracing::error!(error = %e, "rx dropped before stream ended");
+            }
             Ok(())
         }
         e => {
-            // propagate other errors
-            tx.send(Err(InternalError::StreamError(Box::new(e))))?;
+            if let Err(e) = tx.send(Err(ApiError::StreamError(Box::new(e)))) {
+                tracing::error!(error = %e, "rx dropped before stream ended");
+            }
             Ok(())
         }
     }

--- a/ai-gateway/src/dispatcher/mod.rs
+++ b/ai-gateway/src/dispatcher/mod.rs
@@ -13,8 +13,8 @@ use bytes::Bytes;
 use futures::Stream;
 
 pub use self::service::{Dispatcher, DispatcherService};
-use crate::error::internal::InternalError;
+use crate::error::api::ApiError;
 
 pub(crate) type BoxTryStream<I> =
-    Pin<Box<dyn Stream<Item = Result<I, InternalError>> + Send>>;
+    Pin<Box<dyn Stream<Item = Result<I, ApiError>> + Send>>;
 pub(crate) type SSEStream = BoxTryStream<Bytes>;

--- a/ai-gateway/src/error/internal.rs
+++ b/ai-gateway/src/error/internal.rs
@@ -60,8 +60,6 @@ pub enum InternalError {
     MappingTaskError(tokio::task::JoinError),
     /// Converter not present for {0:?} -> {1:?}
     InvalidConverter(ApiEndpoint, ApiEndpoint),
-    /// Stream error: {0}
-    StreamError(Box<reqwest_eventsource::Error>),
     /// Upstream 5xx error: {0}
     Provider5xxError(StatusCode),
     /// Metrics not configured for: {0:?}
@@ -168,7 +166,6 @@ impl From<&InternalError> for InternalErrorMetric {
             InternalError::InvalidHeader(_) => Self::InvalidHeader,
             InternalError::MappingTaskError(_) => Self::TokioTaskError,
             InternalError::InvalidConverter(_, _) => Self::InvalidConverter,
-            InternalError::StreamError(_) => Self::StreamError,
             InternalError::Provider5xxError(_) => Self::Provider5xxError,
             InternalError::MetricsNotConfigured(_) => {
                 Self::MetricsNotConfigured

--- a/ai-gateway/src/error/mapper.rs
+++ b/ai-gateway/src/error/mapper.rs
@@ -22,8 +22,6 @@ pub enum MapperError {
     InvalidRequest,
     /// Serde error: {0}
     SerdeError(#[from] serde_json::Error),
-    /// Underlying stream error: {0}
-    StreamError(String),
     /// Empty response body
     EmptyResponseBody,
     /// Provider not supported: {0}
@@ -53,8 +51,6 @@ pub enum MapperErrorMetric {
     InvalidRequest,
     /// Serde error
     SerdeError,
-    /// Underlying stream error
-    StreamError,
     /// Empty response body
     EmptyResponseBody,
     /// Provider not supported
@@ -77,7 +73,6 @@ impl From<&MapperError> for MapperErrorMetric {
             MapperError::ProviderNotEnabled(_) => Self::ProviderNotEnabled,
             MapperError::InvalidRequest => Self::InvalidRequest,
             MapperError::SerdeError(_) => Self::SerdeError,
-            MapperError::StreamError(_) => Self::StreamError,
             MapperError::EmptyResponseBody => Self::EmptyResponseBody,
             MapperError::ProviderNotSupported(_) => Self::ProviderNotSupported,
             MapperError::ToolMappingInvalid(_) => Self::ToolMappingInvalid,

--- a/ai-gateway/src/middleware/cache/service.rs
+++ b/ai-gateway/src/middleware/cache/service.rs
@@ -252,7 +252,7 @@ async fn check_cache(
             let (resp_parts, resp_body) = response.into_parts();
             let stream = futures::TryStreamExt::map_err(
                 resp_body.into_data_stream(),
-                InternalError::CollectBodyError,
+                |e| InternalError::CollectBodyError(e).into(),
             );
 
             let (user_resp_body, body_reader, tfft_rx) =

--- a/ai-gateway/src/middleware/mapper/bedrock.rs
+++ b/ai-gateway/src/middleware/mapper/bedrock.rs
@@ -654,16 +654,6 @@ impl
         resp_parts: &Parts,
         _value: crate::endpoints::bedrock::converse::ConverseError,
     ) -> Result<async_openai::error::WrappedError, Self::Error> {
-        let kind = super::openai::get_error_type(resp_parts);
-        let code = super::openai::get_error_code(resp_parts);
-        let error = async_openai::error::WrappedError {
-            error: async_openai::error::ApiError {
-                message: kind.clone(),
-                code,
-                param: None,
-                r#type: Some(kind),
-            },
-        };
-        Ok(error)
+        Ok(super::openai_error_from_status(resp_parts.status, None))
     }
 }

--- a/ai-gateway/src/middleware/mapper/mod.rs
+++ b/ai-gateway/src/middleware/mapper/mod.rs
@@ -31,8 +31,9 @@ pub mod openai;
 pub mod registry;
 pub mod service;
 
+use async_openai::error::WrappedError;
 use bytes::Bytes;
-use http::response::Parts;
+use http::{StatusCode, response::Parts};
 use serde::{Serialize, de::DeserializeOwned};
 
 pub use self::service::*;
@@ -248,5 +249,23 @@ where
 
             Ok(Some(Bytes::from(target_bytes)))
         }
+    }
+}
+
+pub(crate) fn openai_error_from_status(
+    status_code: StatusCode,
+    message: Option<String>,
+) -> WrappedError {
+    let kind = self::openai::get_error_type(status_code);
+    let code = self::openai::get_error_code(status_code);
+    let message = message.unwrap_or_else(|| kind.clone());
+
+    async_openai::error::WrappedError {
+        error: async_openai::error::ApiError {
+            message,
+            code,
+            param: None,
+            r#type: Some(kind),
+        },
     }
 }

--- a/ai-gateway/src/middleware/mapper/openai.rs
+++ b/ai-gateway/src/middleware/mapper/openai.rs
@@ -651,22 +651,22 @@ impl
     }
 }
 
-pub(super) fn get_error_type(resp_parts: &Parts) -> String {
-    if resp_parts.status == StatusCode::TOO_MANY_REQUESTS {
+pub(super) fn get_error_type(status_code: StatusCode) -> String {
+    if status_code == StatusCode::TOO_MANY_REQUESTS {
         "tokens".to_string()
-    } else if resp_parts.status.is_client_error() {
+    } else if status_code.is_client_error() {
         INVALID_REQUEST_ERROR_TYPE.to_string()
     } else {
         SERVER_ERROR_TYPE.to_string()
     }
 }
 
-pub(super) fn get_error_code(resp_parts: &Parts) -> Option<String> {
-    if resp_parts.status == StatusCode::UNAUTHORIZED
-        || resp_parts.status == StatusCode::FORBIDDEN
+pub(super) fn get_error_code(status_code: StatusCode) -> Option<String> {
+    if status_code == StatusCode::UNAUTHORIZED
+        || status_code == StatusCode::FORBIDDEN
     {
         Some("invalid_api_key".to_string())
-    } else if resp_parts.status == StatusCode::TOO_MANY_REQUESTS {
+    } else if status_code == StatusCode::TOO_MANY_REQUESTS {
         Some("rate_limit_exceeded".to_string())
     } else {
         None

--- a/ai-gateway/src/middleware/mapper/service.rs
+++ b/ai-gateway/src/middleware/mapper/service.rs
@@ -200,7 +200,7 @@ async fn map_response(
         // SSE event in this branch
         let mapped_stream = body
             .into_data_stream()
-            .map_err(|e| ApiError::Internal(InternalError::CollectBodyError(e)))
+            .map_err(|e| ApiError::Box(e.into_inner()))
             .try_filter_map({
                 let captured_registry = converter_registry.clone();
                 let resp_parts = parts.clone();

--- a/scripts/test/src/main.rs
+++ b/scripts/test/src/main.rs
@@ -225,7 +225,7 @@ async fn run_forever_loop(
     request_type: RequestType,
     model: String,
 ) {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let mut request_count = 0u64;
     let start_time = Instant::now();
 
@@ -250,7 +250,7 @@ async fn run_forever_loop(
                     println!("Requests sent: {}, Current RPS: {:.2}", request_count, current_rps);
                 }
 
-                let delay_ms = rng.gen_range(0..=2);
+                let delay_ms = rng.random_range(0..=2);
                 sleep(Duration::from_millis(delay_ms)).await;
             } => {}
         }

--- a/scripts/typescript-example/index.ts
+++ b/scripts/typescript-example/index.ts
@@ -9,7 +9,7 @@ async function main() {
 
   const response = await client.chat.completions.create({
     // 100+ models available
-    model: "anthropic/claude-sonnet-4-0",
+    model: "openai/gpt-4o-mini",
     messages: [
       {
           role: "system",


### PR DESCRIPTION
previously we were not properly propagating errors in streams which meant that clients would see disconnects instead of e.g. 401 errors