### PR TITLE
fix: propagate errors from streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "ai-gateway"
-version = "0.2.0-beta.16"
+version = "0.2.0-beta.18"
 dependencies = [
  "anthropic-ai-sdk",
  "async-openai",
@@ -3192,7 +3192,7 @@ dependencies = [
 
 [[package]]
 name = "mock-server"
-version = "0.2.0-beta.16"
+version = "0.2.0-beta.18"
 dependencies = [
  "ai-gateway",
  "axum",
@@ -5546,7 +5546,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "telemetry"
-version = "0.2.0-beta.16"
+version = "0.2.0-beta.18"
 dependencies = [
  "http 1.3.1",
  "log-panics",
@@ -6522,7 +6522,7 @@ dependencies = [
 
 [[package]]
 name = "weighted-balance"
-version = "0.2.0-beta.16"
+version = "0.2.0-beta.18"
 dependencies = [
  "futures",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2024"
 authors = [ "Thomas Harmon <tom@helicone.ai>, Justin Torre <justin@helicone.ai>, Kavin Desi Valli <kavin@helicone.ai>, Charlie Wu <charlie@helicone.ai>", "Helicone Developers" ]
 license = "Apache-2.0"
 publish = false
-version = "0.2.0-beta.16"
+version = "0.2.0-beta.18"
 
 
 [profile.release]

--- a/ai-gateway/src/control_plane/types.rs
+++ b/ai-gateway/src/control_plane/types.rs
@@ -149,7 +149,8 @@ mod tests {
     use super::*;
 
     #[test]
-    #[ignore]
+    #[ignore = "run explicitly with `cargo test export_types` when you want to \
+                update the bindings"]
     fn export_types() {
         fn generate_exports(dir: &Path) -> Option<Vec<String>> {
             let mut exports: Vec<String> = fs::read_dir(dir)

--- a/ai-gateway/src/control_plane/websocket.rs
+++ b/ai-gateway/src/control_plane/websocket.rs
@@ -287,9 +287,7 @@ mod tests {
             helicone_config,
         );
         let result = timeout(Duration::from_secs(1), connect_fut).await;
-        let result = if let Ok(r) = result {
-            r
-        } else {
+        let Ok(result) = result else {
             println!("timed out connecting to control plane, passing test");
             return;
         };

--- a/ai-gateway/src/discover/monitor/metrics.rs
+++ b/ai-gateway/src/discover/monitor/metrics.rs
@@ -80,8 +80,8 @@ impl EndpointMetrics {
             }
             reqwest_eventsource::Error::InvalidStatusCode(status_code, ..) => {
                 if status_code.is_server_error() {
+                    tracing::error!(status_code = %status_code, "got upstream server error in stream");
                     self.incr_remote_internal_error_count();
-                    tracing::error!(status_code = %status_code, "received error response in stream");
                 } else if status_code.is_client_error() {
                     tracing::debug!(status_code = %status_code, "got upstream client error in stream");
                 }

--- a/ai-gateway/src/dispatcher/mod.rs
+++ b/ai-gateway/src/dispatcher/mod.rs
@@ -13,8 +13,8 @@ use bytes::Bytes;
 use futures::Stream;
 
 pub use self::service::{Dispatcher, DispatcherService};
-use crate::error::internal::InternalError;
+use crate::error::api::ApiError;
 
 pub(crate) type BoxTryStream<I> =
-    Pin<Box<dyn Stream<Item = Result<I, InternalError>> + Send>>;
+    Pin<Box<dyn Stream<Item = Result<I, ApiError>> + Send>>;
 pub(crate) type SSEStream = BoxTryStream<Bytes>;

--- a/ai-gateway/src/error/internal.rs
+++ b/ai-gateway/src/error/internal.rs
@@ -12,6 +12,7 @@ use crate::{
         api::{ErrorDetails, ErrorResponse},
         mapper::MapperErrorMetric,
     },
+    middleware::mapper::openai::SERVER_ERROR_TYPE,
     types::{json::Json, provider::InferenceProvider},
 };
 
@@ -60,8 +61,6 @@ pub enum InternalError {
     MappingTaskError(tokio::task::JoinError),
     /// Converter not present for {0:?} -> {1:?}
     InvalidConverter(ApiEndpoint, ApiEndpoint),
-    /// Stream error: {0}
-    StreamError(Box<reqwest_eventsource::Error>),
     /// Upstream 5xx error: {0}
     Provider5xxError(StatusCode),
     /// Metrics not configured for: {0:?}
@@ -80,7 +79,7 @@ impl IntoResponse for InternalError {
             Json(ErrorResponse {
                 error: ErrorDetails {
                     message: self.to_string(),
-                    r#type: Some("server_error".to_string()),
+                    r#type: Some(SERVER_ERROR_TYPE.to_string()),
                     param: None,
                     code: None,
                 },
@@ -168,7 +167,6 @@ impl From<&InternalError> for InternalErrorMetric {
             InternalError::InvalidHeader(_) => Self::InvalidHeader,
             InternalError::MappingTaskError(_) => Self::TokioTaskError,
             InternalError::InvalidConverter(_, _) => Self::InvalidConverter,
-            InternalError::StreamError(_) => Self::StreamError,
             InternalError::Provider5xxError(_) => Self::Provider5xxError,
             InternalError::MetricsNotConfigured(_) => {
                 Self::MetricsNotConfigured

--- a/ai-gateway/src/error/mapper.rs
+++ b/ai-gateway/src/error/mapper.rs
@@ -22,8 +22,6 @@ pub enum MapperError {
     InvalidRequest,
     /// Serde error: {0}
     SerdeError(#[from] serde_json::Error),
-    /// Underlying stream error: {0}
-    StreamError(String),
     /// Empty response body
     EmptyResponseBody,
     /// Provider not supported: {0}
@@ -53,8 +51,6 @@ pub enum MapperErrorMetric {
     InvalidRequest,
     /// Serde error
     SerdeError,
-    /// Underlying stream error
-    StreamError,
     /// Empty response body
     EmptyResponseBody,
     /// Provider not supported
@@ -77,7 +73,6 @@ impl From<&MapperError> for MapperErrorMetric {
             MapperError::ProviderNotEnabled(_) => Self::ProviderNotEnabled,
             MapperError::InvalidRequest => Self::InvalidRequest,
             MapperError::SerdeError(_) => Self::SerdeError,
-            MapperError::StreamError(_) => Self::StreamError,
             MapperError::EmptyResponseBody => Self::EmptyResponseBody,
             MapperError::ProviderNotSupported(_) => Self::ProviderNotSupported,
             MapperError::ToolMappingInvalid(_) => Self::ToolMappingInvalid,

--- a/ai-gateway/src/error/mod.rs
+++ b/ai-gateway/src/error/mod.rs
@@ -7,6 +7,7 @@ pub mod logger;
 pub mod mapper;
 pub mod provider;
 pub mod runtime;
+pub mod stream;
 
 pub trait ErrorMetric {
     /// Convert an error type into a low-cardinality string

--- a/ai-gateway/src/error/stream.rs
+++ b/ai-gateway/src/error/stream.rs
@@ -1,0 +1,126 @@
+use axum_core::response::{IntoResponse, Response};
+use displaydoc::Display;
+use http::StatusCode;
+use thiserror::Error;
+
+use super::api::ErrorResponse;
+use crate::{
+    error::api::ErrorDetails,
+    middleware::mapper::openai::{
+        INVALID_REQUEST_ERROR_TYPE, SERVER_ERROR_TYPE,
+    },
+    types::json::Json,
+};
+
+#[derive(Debug, strum::AsRefStr, Error, Display)]
+pub enum StreamError {
+    /// Stream error: {0}
+    StreamError(#[from] Box<reqwest_eventsource::Error>),
+    /// Body error: {0}
+    BodyError(axum_core::Error),
+}
+
+impl IntoResponse for StreamError {
+    fn into_response(self) -> Response {
+        match self {
+            Self::StreamError(error) => {
+                if let reqwest_eventsource::Error::InvalidStatusCode(
+                    status_code,
+                    _response,
+                ) = &*error
+                {
+                    if status_code.is_server_error() {
+                        tracing::error!(error = %error, "upstream server error in stream");
+                        (
+                            *status_code,
+                            Json(ErrorResponse {
+                                error: ErrorDetails {
+                                    message: error.to_string(),
+                                    r#type: Some(SERVER_ERROR_TYPE.to_string()),
+                                    param: None,
+                                    code: None,
+                                },
+                            }),
+                        )
+                            .into_response()
+                    } else if status_code.is_client_error() {
+                        tracing::debug!(error = %error, "invalid request error in stream");
+                        (
+                            *status_code,
+                            Json(ErrorResponse {
+                                error: ErrorDetails {
+                                    message: error.to_string(),
+                                    r#type: Some(
+                                        INVALID_REQUEST_ERROR_TYPE.to_string(),
+                                    ),
+                                    param: None,
+                                    code: None,
+                                },
+                            }),
+                        )
+                            .into_response()
+                    } else {
+                        (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            Json(ErrorResponse {
+                                error: ErrorDetails {
+                                    message: error.to_string(),
+                                    r#type: Some(SERVER_ERROR_TYPE.to_string()),
+                                    param: None,
+                                    code: None,
+                                },
+                            }),
+                        )
+                            .into_response()
+                    }
+                } else {
+                    tracing::error!(error = %error, "internal error in stream");
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(ErrorResponse {
+                            error: ErrorDetails {
+                                message: error.to_string(),
+                                r#type: Some(SERVER_ERROR_TYPE.to_string()),
+                                param: None,
+                                code: None,
+                            },
+                        }),
+                    )
+                        .into_response()
+                }
+            }
+            Self::BodyError(error) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: ErrorDetails {
+                        message: error.to_string(),
+                        r#type: Some(SERVER_ERROR_TYPE.to_string()),
+                        param: None,
+                        code: None,
+                    },
+                }),
+            )
+                .into_response(),
+        }
+    }
+}
+
+/// Auth errors for metrics. This is a special type
+/// that avoids including dynamic information to limit cardinality
+/// such that we can use this type in metrics.
+#[derive(Debug, Error, Display, strum::AsRefStr)]
+pub enum StreamErrorMetric {
+    /// Event stream error
+    StreamError,
+    /// Body error
+    BodyError,
+}
+
+impl From<&StreamError> for StreamErrorMetric {
+    fn from(error: &StreamError) -> Self {
+        match error {
+            StreamError::StreamError(_) => Self::StreamError,
+            StreamError::BodyError(_) => Self::BodyError,
+        }
+    }
+}

--- a/ai-gateway/src/middleware/cache/service.rs
+++ b/ai-gateway/src/middleware/cache/service.rs
@@ -252,7 +252,7 @@ async fn check_cache(
             let (resp_parts, resp_body) = response.into_parts();
             let stream = futures::TryStreamExt::map_err(
                 resp_body.into_data_stream(),
-                InternalError::CollectBodyError,
+                |e| InternalError::CollectBodyError(e).into(),
             );
 
             let (user_resp_body, body_reader, tfft_rx) =

--- a/ai-gateway/src/middleware/mapper/bedrock.rs
+++ b/ai-gateway/src/middleware/mapper/bedrock.rs
@@ -654,16 +654,6 @@ impl
         resp_parts: &Parts,
         _value: crate::endpoints::bedrock::converse::ConverseError,
     ) -> Result<async_openai::error::WrappedError, Self::Error> {
-        let kind = super::openai::get_error_type(resp_parts);
-        let code = super::openai::get_error_code(resp_parts);
-        let error = async_openai::error::WrappedError {
-            error: async_openai::error::ApiError {
-                message: kind.clone(),
-                code,
-                param: None,
-                r#type: Some(kind),
-            },
-        };
-        Ok(error)
+        Ok(super::openai_error_from_status(resp_parts.status, None))
     }
 }

--- a/ai-gateway/src/middleware/mapper/mod.rs
+++ b/ai-gateway/src/middleware/mapper/mod.rs
@@ -31,8 +31,9 @@ pub mod openai;
 pub mod registry;
 pub mod service;
 
+use async_openai::error::WrappedError;
 use bytes::Bytes;
-use http::response::Parts;
+use http::{StatusCode, response::Parts};
 use serde::{Serialize, de::DeserializeOwned};
 
 pub use self::service::*;
@@ -248,5 +249,23 @@ where
 
             Ok(Some(Bytes::from(target_bytes)))
         }
+    }
+}
+
+pub(crate) fn openai_error_from_status(
+    status_code: StatusCode,
+    message: Option<String>,
+) -> WrappedError {
+    let kind = self::openai::get_error_type(status_code);
+    let code = self::openai::get_error_code(status_code);
+    let message = message.unwrap_or_else(|| kind.clone());
+
+    async_openai::error::WrappedError {
+        error: async_openai::error::ApiError {
+            message,
+            code,
+            param: None,
+            r#type: Some(kind),
+        },
     }
 }

--- a/ai-gateway/src/middleware/mapper/openai.rs
+++ b/ai-gateway/src/middleware/mapper/openai.rs
@@ -651,22 +651,22 @@ impl
     }
 }
 
-pub(super) fn get_error_type(resp_parts: &Parts) -> String {
-    if resp_parts.status == StatusCode::TOO_MANY_REQUESTS {
+pub(super) fn get_error_type(status_code: StatusCode) -> String {
+    if status_code == StatusCode::TOO_MANY_REQUESTS {
         "tokens".to_string()
-    } else if resp_parts.status.is_client_error() {
+    } else if status_code.is_client_error() {
         INVALID_REQUEST_ERROR_TYPE.to_string()
     } else {
         SERVER_ERROR_TYPE.to_string()
     }
 }
 
-pub(super) fn get_error_code(resp_parts: &Parts) -> Option<String> {
-    if resp_parts.status == StatusCode::UNAUTHORIZED
-        || resp_parts.status == StatusCode::FORBIDDEN
+pub(super) fn get_error_code(status_code: StatusCode) -> Option<String> {
+    if status_code == StatusCode::UNAUTHORIZED
+        || status_code == StatusCode::FORBIDDEN
     {
         Some("invalid_api_key".to_string())
-    } else if resp_parts.status == StatusCode::TOO_MANY_REQUESTS {
+    } else if status_code == StatusCode::TOO_MANY_REQUESTS {
         Some("rate_limit_exceeded".to_string())
     } else {
         None

--- a/ai-gateway/src/middleware/mapper/service.rs
+++ b/ai-gateway/src/middleware/mapper/service.rs
@@ -10,7 +10,10 @@ use tracing::{Instrument, info_span};
 
 use crate::{
     endpoints::ApiEndpoint,
-    error::{api::ApiError, internal::InternalError, mapper::MapperError},
+    error::{
+        api::ApiError, internal::InternalError, mapper::MapperError,
+        stream::StreamError,
+    },
     middleware::mapper::registry::EndpointConverterRegistry,
     types::{
         extensions::MapperContext, provider::InferenceProvider,
@@ -200,7 +203,7 @@ async fn map_response(
         // SSE event in this branch
         let mapped_stream = body
             .into_data_stream()
-            .map_err(|e| ApiError::Internal(InternalError::CollectBodyError(e)))
+            .map_err(|e| ApiError::StreamError(StreamError::BodyError(e)))
             .try_filter_map({
                 let captured_registry = converter_registry.clone();
                 let resp_parts = parts.clone();

--- a/scripts/test/src/main.rs
+++ b/scripts/test/src/main.rs
@@ -225,7 +225,7 @@ async fn run_forever_loop(
     request_type: RequestType,
     model: String,
 ) {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let mut request_count = 0u64;
     let start_time = Instant::now();
 
@@ -250,7 +250,7 @@ async fn run_forever_loop(
                     println!("Requests sent: {}, Current RPS: {:.2}", request_count, current_rps);
                 }
 
-                let delay_ms = rng.gen_range(0..=2);
+                let delay_ms = rng.random_range(0..=2);
                 sleep(Duration::from_millis(delay_ms)).await;
             } => {}
         }

--- a/scripts/typescript-example/index.ts
+++ b/scripts/typescript-example/index.ts
@@ -9,7 +9,7 @@ async function main() {
 
   const response = await client.chat.completions.create({
     // 100+ models available
-    model: "anthropic/claude-sonnet-4-0",
+    model: "openai/gpt-4o-mini",
     messages: [
       {
           role: "system",


### PR DESCRIPTION
previously we were not properly propagating errors in streams which meant that clients would see disconnects instead of e.g. 401 errors