### PR TITLE
fix: allow default model mappings in config yaml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "ai-gateway"
-version = "0.2.0-beta.18"
+version = "0.2.0-beta.19"
 dependencies = [
  "anthropic-ai-sdk",
  "async-openai",
@@ -3192,7 +3192,7 @@ dependencies = [
 
 [[package]]
 name = "mock-server"
-version = "0.2.0-beta.18"
+version = "0.2.0-beta.19"
 dependencies = [
  "ai-gateway",
  "axum",
@@ -5546,7 +5546,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "telemetry"
-version = "0.2.0-beta.18"
+version = "0.2.0-beta.19"
 dependencies = [
  "http 1.3.1",
  "log-panics",
@@ -6522,7 +6522,7 @@ dependencies = [
 
 [[package]]
 name = "weighted-balance"
-version = "0.2.0-beta.18"
+version = "0.2.0-beta.19"
 dependencies = [
  "futures",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2024"
 authors = [ "Thomas Harmon <tom@helicone.ai>, Justin Torre <justin@helicone.ai>, Kavin Desi Valli <kavin@helicone.ai>, Charlie Wu <charlie@helicone.ai>", "Helicone Developers" ]
 license = "Apache-2.0"
 publish = false
-version = "0.2.0-beta.18"
+version = "0.2.0-beta.19"
 
 
 [profile.release]

--- a/ai-gateway/config/embedded/model-mapping.yaml
+++ b/ai-gateway/config/embedded/model-mapping.yaml
@@ -1,242 +1,242 @@
 # OpenAI Models
 gpt-4:
-  - claude-3-7-sonnet
-  - gemini-2.5-pro
-  - deepseek-r1
+  - "claude-3-7-sonnet"
+  - "gemini-2.5-pro"
+  - "deepseek-r1"
   - "us.deepseek.r1-v1:0"
 gpt-4-turbo:
-  - claude-3-7-sonnet
-  - gemini-2.5-pro
-  - llama4
+  - "claude-3-7-sonnet"
+  - "gemini-2.5-pro"
+  - "llama4"
   - "amazon.nova-sonic-v1:0"
 gpt-4o:
-  - claude-3-7-sonnet
-  - gemini-2.5-pro
-  - llama4
+  - "claude-3-7-sonnet"
+  - "gemini-2.5-pro"
+  - "llama4"
   - "us.deepseek.r1-v1:0"
 gpt-4o-mini:
-  - claude-3-5-haiku
-  - gemini-2.0-flash
-  - llama3.2
-  - llama3
+  - "claude-3-5-haiku"
+  - "gemini-2.0-flash"
+  - "llama3.2"
+  - "llama3"
   - "us.anthropic.claude-3-5-haiku-20241022-v1:0"
 gpt-4.1:
-  - claude-3-7-sonnet
-  - gemini-2.5-pro
-  - llama4
+  - "claude-3-7-sonnet"
+  - "gemini-2.5-pro"
+  - "llama4"
   - "us.deepseek.r1-v1:0"
 gpt-4.1-mini:
-  - claude-3-5-haiku
-  - gemini-2.0-flash
-  - llama3.3
+  - "claude-3-5-haiku"
+  - "gemini-2.0-flash"
+  - "llama3.3"
   - "us.anthropic.claude-3-5-haiku-20241022-v1:0"
 gpt-4.1-nano:
-  - claude-3-5-haiku
-  - gemini-1.5-flash-8b
-  - phi4
+  - "claude-3-5-haiku"
+  - "gemini-1.5-flash-8b"
+  - "phi4"
   - "amazon.nova-micro-v1:0"
 gpt-4.5:
-  - claude-opus-4-0
-  - gemini-2.5-pro
-  - deepseek-r1
+  - "claude-opus-4-0"
+  - "gemini-2.5-pro"
+  - "deepseek-r1"
   - "us.deepseek.r1-v1:0"
 o1:
-  - claude-sonnet-4-0
-  - gemini-2.5-pro
-  - deepseek-r1
+  - "claude-sonnet-4-0"
+  - "gemini-2.5-pro"
+  - "deepseek-r1"
   - "us.deepseek.r1-v1:0"
 o1-mini:
-  - claude-3-5-haiku
-  - gemini-2.0-flash
-  - llama3.3
+  - "claude-3-5-haiku"
+  - "gemini-2.0-flash"
+  - "llama3.3"
   - "us.anthropic.claude-3-5-haiku-20241022-v1:0"
 o1-pro:
-  - claude-opus-4-0
-  - gemini-2.5-pro
+  - "claude-opus-4-0"
+  - "gemini-2.5-pro"
   - "us.deepseek.r1-v1:0"
   - "us.anthropic.claude-opus-4-20250514-v1:0"
 o3:
-  - claude-opus-4-0
-  - gemini-2.5-pro
-  - deepseek-r1
+  - "claude-opus-4-0"
+  - "gemini-2.5-pro"
+  - "deepseek-r1"
   - "us.anthropic.claude-opus-4-20250514-v1:0"
 o3-mini:
-  - claude-3-5-haiku
+  - "claude-3-5-haiku"
   - "us.anthropic.claude-3-5-haiku-20241022-v1:0"
-  - gemini-2.0-flash
-  - llama3.3
+  - "gemini-2.0-flash"
+  - "llama3.3"
   - "anthropic.claude-3-5-sonnet-20240620-v1:0"
 o4-mini:
-  - claude-3-5-haiku
-  - gemini-2.0-flash
-  - gpt-4.1
-  - llama3
+  - "claude-3-5-haiku"
+  - "gemini-2.0-flash"
+  - "gpt-4.1"
+  - "llama3"
   - "us.anthropic.claude-3-5-haiku-20241022-v1:0"
 codex-mini:
-  - claude-3-7-sonnet
-  - gemini-2.0-flash
-  - gemma3
+  - "claude-3-7-sonnet"
+  - "gemini-2.0-flash"
+  - "gemma3"
   - "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
 gpt-4o-mini-search:
-  - claude-3-5-haiku
-  - gemini-1.5-flash
-  - llama3
+  - "claude-3-5-haiku"
+  - "gemini-1.5-flash"
+  - "llama3"
   - "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
 gpt-4o-search:
-  - claude-3-7-sonnet
-  - gemini-2.5-pro
-  - llama4
+  - "claude-3-7-sonnet"
+  - "gemini-2.5-pro"
+  - "llama4"
   - "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
 
 # Anthropic Models
 claude-opus-4-0:
-  - o3
-  - gemini-2.5-pro
-  - deepseek-r1
+  - "o3"
+  - "gemini-2.5-pro"
+  - "deepseek-r1"
   - "us.anthropic.claude-opus-4-20250514-v1:0"
 claude-sonnet-4-0:
-  - o4-mini
-  - gemini-2.0-flash
-  - llama4
+  - "o4-mini"
+  - "gemini-2.0-flash"
+  - "llama4"
   - "us.deepseek.r1-v1:0"
   - "us.anthropic.claude-sonnet-4-20250514-v1:0"
 claude-3-7-sonnet:
-  - o4-mini
-  - gemini-2.0-flash
-  - llama4
+  - "o4-mini"
+  - "gemini-2.0-flash"
+  - "llama4"
   - "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
 claude-3-5-haiku:
-  - gemini-2.0-flash
-  - gpt-4o-mini
-  - llama3
+  - "gemini-2.0-flash"
+  - "gpt-4o-mini"
+  - "llama3"
   - "us.deepseek.r1-v1:0"
   - "us.anthropic.claude-3-5-haiku-20241022-v1:0"
 claude-3-5-sonnet:
-  - o3-mini
-  - gemini-2.0-flash
-  - llama4
+  - "o3-mini"
+  - "gemini-2.0-flash"
+  - "llama4"
   - "us.deepseek.r1-v1:0"
   - "anthropic.claude-3-5-sonnet-20240620-v1:0"
 claude-3-opus:
-  - gpt-4.5
-  - gemini-2.5-pro
-  - deepseek-r1
+  - "gpt-4.5"
+  - "gemini-2.5-pro"
+  - "deepseek-r1"
   - "us.anthropic.claude-3-opus-20240229-v1:0"
 
 # Gemini Models
 gemini-2.5-flash:
-  - gpt-4o-mini
-  - claude-3-5-haiku
-  - gemma3
+  - "gpt-4o-mini"
+  - "claude-3-5-haiku"
+  - "gemma3"
   - "us.anthropic.claude-3-5-haiku-20241022-v1:0"
 gemini-2.5-pro:
-  - gpt-4.5
-  - claude-sonnet-4-0
-  - deepseek-r1
+  - "gpt-4.5"
+  - "claude-sonnet-4-0"
+  - "deepseek-r1"
   - "us.anthropic.claude-sonnet-4-20250514-v1:0"
 gemini-2.0-flash:
-  - gpt-4o-mini
-  - claude-3-5-haiku
-  - llama3
+  - "gpt-4o-mini"
+  - "claude-3-5-haiku"
+  - "llama3"
   - "us.anthropic.claude-3-5-haiku-20241022-v1:0"
 gemini-2.0-flash-lite:
-  - gpt-4o-mini
-  - claude-3-5-haiku
-  - llama3
+  - "gpt-4o-mini"
+  - "claude-3-5-haiku"
+  - "llama3"
   - "amazon.nova-sonic-v1:0"
 gemini-1.5-flash:
-  - gpt-4o-mini
-  - claude-3-5-haiku
-  - llama3
+  - "gpt-4o-mini"
+  - "claude-3-5-haiku"
+  - "llama3"
   - "amazon.nova-sonic-v1:0"
 gemini-1.5-flash-8b:
-  - gpt-4o-mini
-  - claude-3-5-haiku
-  - phi4
+  - "gpt-4o-mini"
+  - "claude-3-5-haiku"
+  - "phi4"
   - "amazon.nova-sonic-v1:0"
 gemini-1.5-pro:
-  - gpt-4o
-  - claude-3-5-sonnet
-  - llama4
+  - "gpt-4o"
+  - "claude-3-5-sonnet"
+  - "llama4"
   - "anthropic.claude-3-5-sonnet-20240620-v1:0"
 
 # Bedrock models
 "us.anthropic.claude-3-5-haiku-20241022-v1:0":
-  - gemini-2.0-flash
-  - gpt-4o-mini
-  - claude-3-5-haiku
+  - "gemini-2.0-flash"
+  - "gpt-4o-mini"
+  - "claude-3-5-haiku"
   - "us.deepseek.r1-v1:0"
 "anthropic.claude-3-5-sonnet-20240620-v1:0":
-  - o3-mini
-  - gemini-2.0-flash
-  - claude-3-5-sonnet
+  - "o3-mini"
+  - "gemini-2.0-flash"
+  - "claude-3-5-sonnet"
   - "us.deepseek.r1-v1:0"
 "us.anthropic.claude-3-opus-20240229-v1:0":
-  - gpt-4.5
-  - gemini-2.5-pro
-  - claude-3-opus
-  - claude-3-7-sonnet
+  - "gpt-4.5"
+  - "gemini-2.5-pro"
+  - "claude-3-opus"
+  - "claude-3-7-sonnet"
   - "us.deepseek.r1-v1:0"
 "us.anthropic.claude-3-7-sonnet-20250219-v1:0":
-  - o4-mini
-  - gemini-2.0-flash
+  - "o4-mini"
+  - "gemini-2.0-flash"
   - "us.deepseek.r1-v1:0"
-  - claude-3-7-sonnet
+  - "claude-3-7-sonnet"
 "us.anthropic.claude-opus-4-20250514-v1:0":
-  - o3
-  - gemini-2.5-pro
+  - "o3"
+  - "gemini-2.5-pro"
   - "us.deepseek.r1-v1:0"
-  - claude-opus-4-0
+  - "claude-opus-4-0"
 "us.anthropic.claude-sonnet-4-20250514-v1:0":
-  - o4-mini
-  - gemini-2.0-flash
+  - "o4-mini"
+  - "gemini-2.0-flash"
   - "us.deepseek.r1-v1:0"
-  - claude-sonnet-4-0
+  - "claude-sonnet-4-0"
 "us.deepseek.r1-v1:0":
-  - gpt-4o
-  - claude-3-5-sonnet
-  - gemini-2.0-flash
-  - claude-3-7-sonnet
+  - "gpt-4o"
+  - "claude-3-5-sonnet"
+  - "gemini-2.0-flash"
+  - "claude-3-7-sonnet"
 
 # Ollama Models
 deepseek-r1:
-  - gpt-4o
-  - claude-3-5-sonnet
-  - gemini-2.0-flash
+  - "gpt-4o"
+  - "claude-3-5-sonnet"
+  - "gemini-2.0-flash"
   - "us.deepseek.r1-v1:0"
 llama4:
-  - gpt-4o
-  - claude-3-5-sonnet
-  - gemini-2.0-flash
+  - "gpt-4o"
+  - "claude-3-5-sonnet"
+  - "gemini-2.0-flash"
   # bedrock doesn't have fullsize llama4
   - "us.deepseek.r1-v1:0"
 llama3.3:
-  - gpt-4o-mini
-  - claude-3-5-haiku
-  - gemini-1.5-flash
+  - "gpt-4o-mini"
+  - "claude-3-5-haiku"
+  - "gemini-1.5-flash"
   - "meta.llama3-8b-instruct-v1:0"
 llama3:
-  - gpt-4o-mini
-  - claude-3-5-haiku
-  - gemini-1.5-flash
+  - "gpt-4o-mini"
+  - "claude-3-5-haiku"
+  - "gemini-1.5-flash"
   - "meta.llama3-8b-instruct-v1:0"
 gemma3:
-  - gpt-4o-mini
-  - claude-3-5-haiku
-  - gemini-1.5-flash
+  - "gpt-4o-mini"
+  - "claude-3-5-haiku"
+  - "gemini-1.5-flash"
   - "us.deepseek.r1-v1:0"
 qwen3:
-  - gpt-4o-mini
-  - claude-3-5-haiku
-  - gemini-1.5-flash
+  - "gpt-4o-mini"
+  - "claude-3-5-haiku"
+  - "gemini-1.5-flash"
   - "us.deepseek.r1-v1:0"
 phi4:
-  - gpt-4o-mini
-  - claude-3-5-haiku
-  - gemini-1.5-flash
+  - "gpt-4o-mini"
+  - "claude-3-5-haiku"
+  - "gemini-1.5-flash"
   - "amazon.nova-lite-v1:0"
 llava:
-  - gpt-4o-mini
-  - claude-3-5-haiku
-  - gemini-1.5-flash
+  - "gpt-4o-mini"
+  - "claude-3-5-haiku"
+  - "gemini-1.5-flash"
   - "us.deepseek.r1-v1:0"

--- a/ai-gateway/config/embedded/providers.yaml
+++ b/ai-gateway/config/embedded/providers.yaml
@@ -1,65 +1,65 @@
 openai:
   enabled: true
   models:
-    - gpt-4
-    - gpt-4-turbo
-    - gpt-4o
-    - gpt-4o-mini
-    - gpt-4.1
-    - gpt-4.1-mini
-    - gpt-4.1-nano
-    - gpt-4.5
-    - o1
-    - o1-mini
-    - o1-pro
-    - o3
-    - o3-mini
-    - o4-mini
-    - codex-mini
-    - gpt-4o-mini-search
-    - gpt-4o-search
+    - "gpt-4"
+    - "gpt-4-turbo"
+    - "gpt-4o"
+    - "gpt-4o-mini"
+    - "gpt-4.1"
+    - "gpt-4.1-mini"
+    - "gpt-4.1-nano"
+    - "gpt-4.5"
+    - "o1"
+    - "o1-mini"
+    - "o1-pro"
+    - "o3"
+    - "o3-mini"
+    - "o4-mini"
+    - "codex-mini"
+    - "gpt-4o-mini-search"
+    - "gpt-4o-search"
   base-url: https://api.openai.com
   version: null
 
 anthropic:
   enabled: true
   models:
-    - claude-opus-4-0
-    - claude-sonnet-4-0
+    - "claude-opus-4-0"
+    - "claude-sonnet-4-0"
     # the alias Anthropic provides for these below models require that it
     # include an explicit `-latest` suffix when sent to Antrhopic
-    - claude-3-7-sonnet
-    - claude-3-5-haiku
-    - claude-3-5-sonnet
-    - claude-3-opus
+    - "claude-3-7-sonnet"
+    - "claude-3-5-haiku"
+    - "claude-3-5-sonnet"
+    - "claude-3-opus"
   base-url: https://api.anthropic.com
   version: "2023-06-01"
 
 gemini:
   enabled: true
   models:
-    - gemini-2.5-flash
-    - gemini-2.5-pro
-    - gemini-2.0-flash
-    - gemini-2.0-flash-lite
-    - gemini-1.5-flash
-    - gemini-1.5-flash-8b
-    - gemini-1.5-pro
+    - "gemini-2.5-flash"
+    - "gemini-2.5-pro"
+    - "gemini-2.0-flash"
+    - "gemini-2.0-flash-lite"
+    - "gemini-1.5-flash"
+    - "gemini-1.5-flash-8b"
+    - "gemini-1.5-pro"
   base-url: https://generativelanguage.googleapis.com
   version: null
 
 ollama:
   enabled: false
   models:
-    - deepseek-r1
-    - gemma3
-    - qwen3
-    - llama4
-    - llama3.3
-    - llama3.2
-    - llama3
-    - phi4
-    - llava
+    - "deepseek-r1"
+    - "gemma3"
+    - "qwen3"
+    - "llama4"
+    - "llama3.3"
+    - "llama3.2"
+    - "llama3"
+    - "phi4"
+    - "llava"
   base-url: http://localhost:11434
 
 bedrock:
@@ -67,37 +67,37 @@ bedrock:
   # bedrock models must be enabled prior to sending
   # requests which use them
   models:
-    - us.anthropic.claude-3-5-haiku-20241022-v1:0
-    - anthropic.claude-3-5-sonnet-20240620-v1:0
-    - us.anthropic.claude-3-opus-20240229-v1:0
-    - us.anthropic.claude-3-7-sonnet-20250219-v1:0
-    - us.anthropic.claude-opus-4-20250514-v1:0
-    - us.anthropic.claude-sonnet-4-20250514-v1:0
-    - us.deepseek.r1-v1:0
-    - us.amazon.nova-premier-v1:0
-    - amazon.titan-text-premier-v1:0
-    - amazon.titan-text-express-v1
-    - amazon.titan-text-lite-v1
-    - amazon.nova-sonic-v1:0
-    - amazon.nova-pro-v1:0
-    - amazon.nova-lite-v1:0
-    - amazon.nova-micro-v1:0
-    - ai21.jamba-1-5-large-v1:0
-    - ai21.jamba-1-5-mini-v1:0
-    - cohere.command-light-text-v14
-    - cohere.command-r-plus-v1:0
-    - cohere.command-text-v14
-    - meta.llama3-8b-instruct-v1:0
-    - meta.llama3-70b-instruct-v1:0
-    - us.meta.llama3-1-8b-instruct-v1:0
-    - us.meta.llama3-2-1b-instruct-v1:0
-    - us.meta.llama3-2-3b-instruct-v1:0
-    - us.meta.llama3-2-90b-instruct-v1:0
-    - us.meta.llama4-maverick-17b-instruct-v1:0
-    - mistral.mistral-7b-instruct-v0:2
-    - mistral.mistral-large-2402-v1:0
-    - mistral.mistral-small-2402-v1:0
-    - mistral.mixtral-8x7b-instruct-v0:1
-    - us.mistral.pixtral-large-2502-v1:0
+    - "us.anthropic.claude-3-5-haiku-20241022-v1:0"
+    - "anthropic.claude-3-5-sonnet-20240620-v1:0"
+    - "us.anthropic.claude-3-opus-20240229-v1:0"
+    - "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
+    - "us.anthropic.claude-opus-4-20250514-v1:0"
+    - "us.anthropic.claude-sonnet-4-20250514-v1:0"
+    - "us.deepseek.r1-v1:0"
+    - "us.amazon.nova-premier-v1:0"
+    - "amazon.titan-text-premier-v1:0"
+    - "amazon.titan-text-express-v1"
+    - "amazon.titan-text-lite-v1"
+    - "amazon.nova-sonic-v1:0"
+    - "amazon.nova-pro-v1:0"
+    - "amazon.nova-lite-v1:0"
+    - "amazon.nova-micro-v1:0"
+    - "ai21.jamba-1-5-large-v1:0"
+    - "ai21.jamba-1-5-mini-v1:0"
+    - "cohere.command-light-text-v14"
+    - "cohere.command-r-plus-v1:0"
+    - "cohere.command-text-v14"
+    - "meta.llama3-8b-instruct-v1:0"
+    - "meta.llama3-70b-instruct-v1:0"
+    - "us.meta.llama3-1-8b-instruct-v1:0"
+    - "us.meta.llama3-2-1b-instruct-v1:0"
+    - "us.meta.llama3-2-3b-instruct-v1:0"
+    - "us.meta.llama3-2-90b-instruct-v1:0"
+    - "us.meta.llama4-maverick-17b-instruct-v1:0"
+    - "mistral.mistral-7b-instruct-v0:2"
+    - "mistral.mistral-large-2402-v1:0"
+    - "mistral.mistral-small-2402-v1:0"
+    - "mistral.mixtral-8x7b-instruct-v0:1"
+    - "us.mistral.pixtral-large-2502-v1:0"
   base-url: https://bedrock-runtime.us-east-1.amazonaws.com
   version: null

--- a/ai-gateway/config/local.yaml
+++ b/ai-gateway/config/local.yaml
@@ -8,6 +8,10 @@ helicone:
   authentication: true
   observability: true
 
+# global:
+#   rate-limit:
+
+
 routers:
   default:
     load-balance:


### PR DESCRIPTION
in PR !180, the ability to set the `default-model-mappings` in config yaml was removed, this PR restores that ability.

unfortunately, this also means reverting a cleaner config merging solution, however, removing the `#[serde(skip)]` attribute means that the Gateway fails to startup with the error message:

```
thread 'main' panicked at ai-gateway/src/config/mod.rs:93:68:
called `Result::unwrap()` on an `Err` value: default-model-mapping.anthropic.claude-3-5-sonnet-20240620-v1:0[0]
                                                              ^
invalid postfix
expected `[`, `.`
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Since configuring these global mappings is a intentional feature

(see [docs](https://docs.helicone.ai/ai-gateway/config#param-default-model-mapping))

we have to revert this cleanup until we can remove the `#[serde(skip)]` and have config deserialization work as expected, including for the default model mappings