### PR TITLE
feat: helicone features config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "ai-gateway"
-version = "0.2.0-beta.19"
+version = "0.2.0-beta.20"
 dependencies = [
  "anthropic-ai-sdk",
  "async-openai",
@@ -3214,7 +3214,7 @@ dependencies = [
 
 [[package]]
 name = "mock-server"
-version = "0.2.0-beta.19"
+version = "0.2.0-beta.20"
 dependencies = [
  "ai-gateway",
  "axum",
@@ -5568,7 +5568,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "telemetry"
-version = "0.2.0-beta.19"
+version = "0.2.0-beta.20"
 dependencies = [
  "http 1.3.1",
  "log-panics",
@@ -6544,7 +6544,7 @@ dependencies = [
 
 [[package]]
 name = "weighted-balance"
-version = "0.2.0-beta.19"
+version = "0.2.0-beta.20"
 dependencies = [
  "futures",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2024"
 authors = [ "Thomas Harmon <tom@helicone.ai>, Justin Torre <justin@helicone.ai>, Kavin Desi Valli <kavin@helicone.ai>, Charlie Wu <charlie@helicone.ai>", "Helicone Developers" ]
 license = "Apache-2.0"
 publish = false
-version = "0.2.0-beta.19"
+version = "0.2.0-beta.20"
 
 
 [profile.release]

--- a/ai-gateway/src/config/helicone.rs
+++ b/ai-gateway/src/config/helicone.rs
@@ -3,7 +3,24 @@ use url::Url;
 
 use crate::types::secret::Secret;
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(
+    Default, Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash,
+)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub enum HeliconeFeatures {
+    /// No features enabled
+    ///
+    /// **Note:** this means no authentication checks, so any request to the
+    /// gateway will be able to use your provider API keys!
+    #[default]
+    None,
+    /// Authentication only.
+    Auth,
+    /// Authentication and observability.
+    All,
+}
+
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct HeliconeConfig {
     /// The API key to authenticate the AI Gateway to the Helicone control
@@ -16,13 +33,27 @@ pub struct HeliconeConfig {
     /// The websocket URL of the Helicone control plane.
     #[serde(default = "default_websocket_url")]
     pub websocket_url: Url,
-    /// Whether to enable authentication.
-    ///
-    /// **Note**: without this enabled, anyone sending requests to your
-    /// AI gateway instance will be able to use your provider API keys!
-    pub authentication: bool,
-    /// Whether to enable LLM observability via Helicone.
-    pub observability: bool,
+    /// The mode of Helicone features to enable.
+    #[serde(default)]
+    pub features: HeliconeFeatures,
+}
+
+impl HeliconeConfig {
+    #[must_use]
+    pub fn is_auth_enabled(&self) -> bool {
+        self.features == HeliconeFeatures::Auth
+            || self.features == HeliconeFeatures::All
+    }
+
+    #[must_use]
+    pub fn is_auth_disabled(&self) -> bool {
+        self.features == HeliconeFeatures::None
+    }
+
+    #[must_use]
+    pub fn is_observability_enabled(&self) -> bool {
+        self.features == HeliconeFeatures::All
+    }
 }
 
 impl Default for HeliconeConfig {
@@ -31,8 +62,7 @@ impl Default for HeliconeConfig {
             api_key: default_api_key(),
             base_url: default_base_url(),
             websocket_url: default_websocket_url(),
-            authentication: false,
-            observability: false,
+            features: HeliconeFeatures::None,
         }
     }
 }
@@ -62,9 +92,351 @@ impl crate::tests::TestDefault for HeliconeConfig {
             websocket_url: "ws://localhost:8585/ws/v1/router/control-plane"
                 .parse()
                 .unwrap(),
-            authentication: true,
-            observability: true,
+            features: HeliconeFeatures::All,
             api_key: default_api_key(),
         }
+    }
+}
+
+// This manual deserialize impl is only required for backwards compatibility so
+// that we can support the old `authentication` and `observability` boolean
+// fields.
+#[allow(clippy::too_many_lines)]
+impl<'de> Deserialize<'de> for HeliconeConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use std::fmt;
+
+        use serde::de::{self, MapAccess, Visitor};
+
+        #[derive(Deserialize)]
+        #[serde(field_identifier, rename_all = "kebab-case")]
+        enum Field {
+            ApiKey,
+            BaseUrl,
+            WebsocketUrl,
+            Features,
+            Authentication,
+            Observability,
+        }
+
+        struct HeliconeConfigVisitor;
+
+        impl<'de> Visitor<'de> for HeliconeConfigVisitor {
+            type Value = HeliconeConfig;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("struct HeliconeConfig")
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map: V,
+            ) -> Result<HeliconeConfig, V::Error>
+            where
+                V: MapAccess<'de>,
+            {
+                let mut api_key = None;
+                let mut base_url = None;
+                let mut websocket_url = None;
+                let mut features = None;
+                let mut authentication = None;
+                let mut observability = None;
+
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::ApiKey => {
+                            if api_key.is_some() {
+                                return Err(de::Error::duplicate_field(
+                                    "api_key",
+                                ));
+                            }
+                            api_key = Some(map.next_value()?);
+                        }
+                        Field::BaseUrl => {
+                            if base_url.is_some() {
+                                return Err(de::Error::duplicate_field(
+                                    "base_url",
+                                ));
+                            }
+                            base_url = Some(map.next_value()?);
+                        }
+                        Field::WebsocketUrl => {
+                            if websocket_url.is_some() {
+                                return Err(de::Error::duplicate_field(
+                                    "websocket_url",
+                                ));
+                            }
+                            websocket_url = Some(map.next_value()?);
+                        }
+                        Field::Features => {
+                            if features.is_some() {
+                                return Err(de::Error::duplicate_field(
+                                    "features",
+                                ));
+                            }
+                            features = Some(map.next_value()?);
+                        }
+                        Field::Authentication => {
+                            if authentication.is_some() {
+                                return Err(de::Error::duplicate_field(
+                                    "authentication",
+                                ));
+                            }
+                            authentication = Some(map.next_value()?);
+                        }
+                        Field::Observability => {
+                            if observability.is_some() {
+                                return Err(de::Error::duplicate_field(
+                                    "observability",
+                                ));
+                            }
+                            observability = Some(map.next_value()?);
+                        }
+                    }
+                }
+
+                // Determine features precedence:
+                // 1. If features is set, use it.
+                // 2. Otherwise, use authentication/observability booleans.
+                // 3. Otherwise, default to None.
+
+                let features = if let Some(f) = features {
+                    f
+                } else {
+                    match (authentication, observability) {
+                        (_, Some(true)) => HeliconeFeatures::All,
+                        (Some(true), Some(false) | None) => {
+                            HeliconeFeatures::Auth
+                        }
+                        _ => HeliconeFeatures::None,
+                    }
+                };
+
+                Ok(HeliconeConfig {
+                    api_key: api_key.unwrap_or_else(default_api_key),
+                    base_url: base_url.unwrap_or_else(default_base_url),
+                    websocket_url: websocket_url
+                        .unwrap_or_else(default_websocket_url),
+                    features,
+                })
+            }
+        }
+
+        const FIELDS: &[&str] = &[
+            "api_key",
+            "base_url",
+            "websocket_url",
+            "features",
+            "authentication",
+            "observability",
+        ];
+        deserializer.deserialize_struct(
+            "HeliconeConfig",
+            FIELDS,
+            HeliconeConfigVisitor,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deserialize_features_field_only() {
+        let yaml = r#"
+api-key: "sk-test-key"
+base-url: "https://example.com"
+websocket-url: "wss://example.com/ws"
+features: "all"
+"#;
+
+        let config: HeliconeConfig = serde_yml::from_str(yaml).unwrap();
+        assert_eq!(config.features, HeliconeFeatures::All);
+    }
+
+    #[test]
+    fn test_deserialize_auth_and_observability_both_true() {
+        let yaml = r#"
+api-key: "sk-test-key"
+authentication: true
+observability: true
+"#;
+
+        let config: HeliconeConfig = serde_yml::from_str(yaml).unwrap();
+        assert_eq!(config.features, HeliconeFeatures::All);
+    }
+
+    #[test]
+    fn test_deserialize_auth_true_observability_false() {
+        let yaml = r#"
+api-key: "sk-test-key"
+authentication: true
+observability: false
+"#;
+
+        let config: HeliconeConfig = serde_yml::from_str(yaml).unwrap();
+        assert_eq!(config.features, HeliconeFeatures::Auth);
+    }
+
+    #[test]
+    fn test_deserialize_auth_false_observability_true() {
+        let yaml = r#"
+api-key: "sk-test-key"
+authentication: false
+observability: true
+"#;
+
+        let config: HeliconeConfig = serde_yml::from_str(yaml).unwrap();
+        assert_eq!(config.features, HeliconeFeatures::All);
+    }
+
+    #[test]
+    fn test_deserialize_auth_and_observability_both_false() {
+        let yaml = r#"
+api-key: "sk-test-key"
+authentication: false
+observability: false
+"#;
+
+        let config: HeliconeConfig = serde_yml::from_str(yaml).unwrap();
+        assert_eq!(config.features, HeliconeFeatures::None);
+    }
+
+    #[test]
+    fn test_deserialize_auth_true_only() {
+        let yaml = r#"
+api-key: "sk-test-key"
+authentication: true
+"#;
+
+        let config: HeliconeConfig = serde_yml::from_str(yaml).unwrap();
+        assert_eq!(config.features, HeliconeFeatures::Auth);
+    }
+
+    #[test]
+    fn test_deserialize_observability_true_only() {
+        let yaml = r#"
+api-key: "sk-test-key"
+observability: true
+"#;
+
+        let config: HeliconeConfig = serde_yml::from_str(yaml).unwrap();
+        assert_eq!(config.features, HeliconeFeatures::All);
+    }
+
+    #[test]
+    fn test_deserialize_auth_false_only() {
+        let yaml = r#"
+api-key: "sk-test-key"
+authentication: false
+"#;
+
+        let config: HeliconeConfig = serde_yml::from_str(yaml).unwrap();
+        assert_eq!(config.features, HeliconeFeatures::None);
+    }
+
+    #[test]
+    fn test_deserialize_observability_false_only() {
+        let yaml = r#"
+api-key: "sk-test-key"
+observability: false
+"#;
+
+        let config: HeliconeConfig = serde_yml::from_str(yaml).unwrap();
+        assert_eq!(config.features, HeliconeFeatures::None);
+    }
+
+    #[test]
+    fn test_deserialize_no_feature_fields() {
+        let yaml = r#"
+api-key: "sk-test-key"
+base-url: "https://example.com"
+"#;
+
+        let config: HeliconeConfig = serde_yml::from_str(yaml).unwrap();
+        assert_eq!(config.features, HeliconeFeatures::None);
+    }
+
+    #[test]
+    fn test_deserialize_features_takes_precedence() {
+        let yaml = r#"
+api-key: "sk-test-key"
+features: "auth"
+authentication: true
+observability: true
+"#;
+
+        let config: HeliconeConfig = serde_yml::from_str(yaml).unwrap();
+        // features field should take precedence over auth/observability
+        assert_eq!(config.features, HeliconeFeatures::Auth);
+    }
+
+    #[test]
+    fn test_deserialize_features_none_with_legacy_fields() {
+        let yaml = r#"
+api-key: "sk-test-key"
+features: "none"
+authentication: true
+observability: true
+"#;
+
+        let config: HeliconeConfig = serde_yml::from_str(yaml).unwrap();
+        // features field should take precedence
+        assert_eq!(config.features, HeliconeFeatures::None);
+    }
+
+    #[test]
+    fn test_deserialize_all_features_variants() {
+        let test_cases = vec![
+            ("none", HeliconeFeatures::None),
+            ("auth", HeliconeFeatures::Auth),
+            ("all", HeliconeFeatures::All),
+        ];
+
+        for (feature_str, expected_feature) in test_cases {
+            let yaml = format!(
+                r#"
+api-key: "sk-test-key"
+features: "{feature_str}"
+"#
+            );
+
+            let config: HeliconeConfig = serde_yml::from_str(&yaml).unwrap();
+            assert_eq!(
+                config.features, expected_feature,
+                "Failed for feature: {feature_str}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_helper_methods() {
+        let auth_config = HeliconeConfig {
+            features: HeliconeFeatures::Auth,
+            ..Default::default()
+        };
+        assert!(auth_config.is_auth_enabled());
+        assert!(!auth_config.is_auth_disabled());
+        assert!(!auth_config.is_observability_enabled());
+
+        let all_config = HeliconeConfig {
+            features: HeliconeFeatures::All,
+            ..Default::default()
+        };
+        assert!(all_config.is_auth_enabled());
+        assert!(!all_config.is_auth_disabled());
+        assert!(all_config.is_observability_enabled());
+
+        let none_config = HeliconeConfig {
+            features: HeliconeFeatures::None,
+            ..Default::default()
+        };
+        assert!(!none_config.is_auth_enabled());
+        assert!(none_config.is_auth_disabled());
+        assert!(!none_config.is_observability_enabled());
     }
 }

--- a/ai-gateway/src/main.rs
+++ b/ai-gateway/src/main.rs
@@ -128,7 +128,7 @@ async fn run_app(config: Config) -> Result<(), RuntimeError> {
         ai_gateway::utils::meltdown::wait_for_shutdown_signals,
     ));
 
-    if app.state.0.config.helicone.authentication {
+    if app.state.0.config.helicone.is_auth_enabled() {
         meltdown = meltdown.register(TaggedService::new(
             "control-plane-client",
             ControlPlaneClient::connect(control_plane_state, helicone_config)

--- a/ai-gateway/src/middleware/auth.rs
+++ b/ai-gateway/src/middleware/auth.rs
@@ -56,7 +56,7 @@ where
     fn authorize(&mut self, mut request: Request<B>) -> Self::Future {
         let app_state = self.app_state.clone();
         Box::pin(async move {
-            if !app_state.0.config.helicone.authentication {
+            if app_state.0.config.helicone.is_auth_disabled() {
                 tracing::trace!("auth middleware: auth disabled");
                 return Ok(request);
             }

--- a/ai-gateway/src/middleware/cache/service.rs
+++ b/ai-gateway/src/middleware/cache/service.rs
@@ -259,13 +259,7 @@ async fn check_cache(
                 BodyReader::wrap_stream(stream, false);
             let response = Response::from_parts(resp_parts, user_resp_body);
 
-            if app_state.config().helicone.observability {
-                if !app_state.config().helicone.authentication {
-                    tracing::warn!(
-                        "Authentication is disabled, skipping response logging"
-                    );
-                    return Ok(CacheCheckResult::Fresh(response));
-                }
+            if app_state.config().helicone.is_observability_enabled() {
                 let auth_ctx =
                     req_parts.extensions.get::<AuthContext>().cloned().ok_or(
                         InternalError::ExtensionNotFound("AuthContext"),

--- a/ai-gateway/tests/auth.rs
+++ b/ai-gateway/tests/auth.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use ai_gateway::{
-    config::Config,
+    config::{Config, helicone::HeliconeFeatures},
     tests::{TestDefault, harness::Harness, mock::MockArgs},
 };
 use http::{Method, Request, StatusCode};
@@ -13,7 +13,7 @@ use tower::Service;
 #[serial_test::serial]
 async fn require_auth_enabled_with_valid_token() {
     let mut config = Config::test_default();
-    config.helicone.authentication = true;
+    config.helicone.features = HeliconeFeatures::All;
 
     let mock_args = MockArgs::builder()
         .stubs(HashMap::from([
@@ -65,7 +65,7 @@ async fn require_auth_enabled_with_valid_token() {
 #[serial_test::serial]
 async fn require_auth_enabled_without_token() {
     let mut config = Config::test_default();
-    config.helicone.authentication = true;
+    config.helicone.features = HeliconeFeatures::Auth;
 
     let mock_args = MockArgs::builder()
         .stubs(HashMap::from([
@@ -112,7 +112,7 @@ async fn require_auth_enabled_without_token() {
 #[serial_test::serial]
 async fn require_auth_disabled_without_token() {
     let mut config = Config::test_default();
-    config.helicone.authentication = false;
+    config.helicone.features = HeliconeFeatures::None;
 
     let mock_args = MockArgs::builder()
         .stubs(HashMap::from([
@@ -156,7 +156,7 @@ async fn require_auth_disabled_without_token() {
 #[serial_test::serial]
 async fn require_auth_disabled_with_token() {
     let mut config = Config::test_default();
-    config.helicone.authentication = false;
+    config.helicone.features = HeliconeFeatures::None;
 
     let mock_args = MockArgs::builder()
         .stubs(HashMap::from([

--- a/ai-gateway/tests/cache.rs
+++ b/ai-gateway/tests/cache.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, time::Duration};
 
 use ai_gateway::{
-    config::Config,
+    config::{Config, helicone::HeliconeFeatures},
     tests::{TestDefault, harness::Harness, mock::MockArgs},
 };
 use http::{Method, Request, StatusCode};
@@ -171,7 +171,7 @@ async fn cache_enabled_globally() {
 #[serial_test::serial(default_mock)]
 async fn cache_disabled_globally() {
     let mut config = Config::test_default();
-    config.helicone.authentication = false;
+    config.helicone.features = HeliconeFeatures::None;
     // Ensure cache is NOT set globally (None by default)
     config.global.cache = None;
 
@@ -297,7 +297,7 @@ async fn cache_enabled_per_router() {
     let mut config = Config::test_default();
     // Disable auth for this test since we're testing basic passthrough
     // functionality
-    config.helicone.authentication = false;
+    config.helicone.features = HeliconeFeatures::None;
     config.global.cache = None;
 
     // Create multiple routers with different cache configurations

--- a/ai-gateway/tests/direct_proxy.rs
+++ b/ai-gateway/tests/direct_proxy.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use ai_gateway::{
-    config::Config,
+    config::{Config, helicone::HeliconeFeatures},
     tests::{TestDefault, harness::Harness, mock::MockArgs},
 };
 use http::{Method, Request, StatusCode};
@@ -16,7 +16,7 @@ async fn openai_direct_proxy() {
     let mut config = Config::test_default();
     // Disable auth for this test since we're testing basic passthrough
     // functionality
-    config.helicone.authentication = false;
+    config.helicone.features = HeliconeFeatures::None;
 
     let mock_args = MockArgs::builder()
         .stubs(HashMap::from([
@@ -59,7 +59,7 @@ async fn anthropic_direct_proxy() {
     let mut config = Config::test_default();
     // Disable auth for this test since we're testing basic passthrough
     // functionality
-    config.helicone.authentication = false;
+    config.helicone.features = HeliconeFeatures::None;
 
     let mock_args = MockArgs::builder()
         .stubs(HashMap::from([

--- a/ai-gateway/tests/error_format.rs
+++ b/ai-gateway/tests/error_format.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use ai_gateway::{
-    config::Config,
+    config::{Config, helicone::HeliconeFeatures},
     tests::{TestDefault, harness::Harness, mock::MockArgs},
 };
 use http::{Method, Request, StatusCode};
@@ -12,7 +12,7 @@ use tower::Service;
 #[serial_test::serial]
 async fn unauthorized() {
     let mut config = Config::test_default();
-    config.helicone.authentication = true;
+    config.helicone.features = HeliconeFeatures::Auth;
 
     let mock_args = MockArgs::builder()
         .stubs(HashMap::from([
@@ -59,7 +59,7 @@ async fn unauthorized() {
 #[serial_test::serial]
 async fn invalid_request_body() {
     let mut config = Config::test_default();
-    config.helicone.authentication = false;
+    config.helicone.features = HeliconeFeatures::None;
 
     let mock_args = MockArgs::builder()
         .stubs(HashMap::from([

--- a/ai-gateway/tests/health_check.rs
+++ b/ai-gateway/tests/health_check.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use ai_gateway::{
-    config::Config,
+    config::{Config, helicone::HeliconeFeatures},
     tests::{TestDefault, harness::Harness, mock::MockArgs},
 };
 use http::{Method, Request, StatusCode};
@@ -11,7 +11,7 @@ use tower::Service;
 #[serial_test::serial]
 async fn health_check() {
     let mut config = Config::test_default();
-    config.helicone.authentication = true;
+    config.helicone.features = HeliconeFeatures::Auth;
 
     let mock_args = MockArgs::builder()
         .stubs(HashMap::from([

--- a/ai-gateway/tests/health_monitor.rs
+++ b/ai-gateway/tests/health_monitor.rs
@@ -4,6 +4,7 @@ use ai_gateway::{
     config::{
         Config,
         balance::{BalanceConfig, BalanceConfigInner, BalanceTarget},
+        helicone::HeliconeFeatures,
         router::{RouterConfig, RouterConfigs},
     },
     discover::monitor::health::HealthMonitor,
@@ -22,8 +23,8 @@ use tower::Service;
 #[serial_test::serial]
 async fn errors_remove_provider_from_lb_pool() {
     let mut config = Config::test_default();
-    // Enable auth so that logging services are called
-    config.helicone.authentication = true;
+    // Enable auth + observability so that logging services are called
+    config.helicone.features = HeliconeFeatures::All;
     let balance_config = BalanceConfig::from(HashMap::from([(
         EndpointType::Chat,
         BalanceConfigInner::Weighted {

--- a/ai-gateway/tests/load_balance.rs
+++ b/ai-gateway/tests/load_balance.rs
@@ -4,6 +4,7 @@ use ai_gateway::{
     config::{
         Config,
         balance::{BalanceConfig, BalanceConfigInner},
+        helicone::HeliconeFeatures,
         router::{RouterConfig, RouterConfigs, RouterRateLimitConfig},
     },
     endpoints::EndpointType,
@@ -43,7 +44,7 @@ fn p2c_config_openai_anthropic_google() -> RouterConfigs {
 async fn openai_slow() {
     let mut config = Config::test_default();
     // Disable auth for this test since we're testing load balancing behavior
-    config.helicone.authentication = false;
+    config.helicone.features = HeliconeFeatures::None;
     // Use p2c balance config with OpenAI, Anthropic, and Google providers
     config.routers = p2c_config_openai_anthropic_google();
     let latency = 100;
@@ -94,7 +95,7 @@ async fn openai_slow() {
 async fn anthropic_slow() {
     let mut config = Config::test_default();
     // Disable auth for this test since we're testing load balancing behavior
-    config.helicone.authentication = false;
+    config.helicone.features = HeliconeFeatures::None;
     // Use p2c balance config with OpenAI, Anthropic, and Google providers
     config.routers = p2c_config_openai_anthropic_google();
     let latency = 10;

--- a/ai-gateway/tests/logger.rs
+++ b/ai-gateway/tests/logger.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use ai_gateway::{
-    config::{Config, DeploymentTarget},
+    config::{Config, DeploymentTarget, helicone::HeliconeFeatures},
     tests::{TestDefault, harness::Harness, mock::MockArgs},
 };
 use http::{Method, Request, StatusCode};
@@ -14,7 +14,7 @@ use tower::Service;
 async fn request_response_logger_authenticated() {
     let mut config = Config::test_default();
     // Ensure auth is required for this test
-    config.helicone.authentication = true;
+    config.helicone.features = HeliconeFeatures::All;
 
     let mock_args = MockArgs::builder()
         .stubs(HashMap::from([
@@ -64,7 +64,7 @@ async fn authenticated_sidecar() {
     let mut config = Config::test_default();
     let minio_port = 9190;
     // Ensure auth is required for this test
-    config.helicone.authentication = true;
+    config.helicone.features = HeliconeFeatures::All;
     config.deployment_target = DeploymentTarget::Sidecar;
 
     let mock_args = MockArgs::builder()
@@ -116,7 +116,7 @@ async fn unauthenticated_sidecar() {
     let mut config = Config::test_default();
     let minio_port = 9190;
     // Ensure auth is required for this test
-    config.helicone.authentication = true;
+    config.helicone.features = HeliconeFeatures::Auth;
     config.deployment_target = DeploymentTarget::Sidecar;
 
     let mock_args = MockArgs::builder()
@@ -160,7 +160,7 @@ async fn unauthenticated_sidecar() {
 async fn request_response_logger_unauthenticated() {
     let mut config = Config::test_default();
     // Disable auth requirement for this test
-    config.helicone.authentication = false;
+    config.helicone.features = HeliconeFeatures::None;
 
     let mock_args = MockArgs::builder()
         .stubs(HashMap::from([
@@ -208,7 +208,7 @@ async fn request_response_logger_unauthenticated() {
 async fn request_response_logger_unauthenticated_sidecar() {
     let mut config = Config::test_default();
     // Disable auth requirement for this test
-    config.helicone.authentication = false;
+    config.helicone.features = HeliconeFeatures::None;
     config.deployment_target = DeploymentTarget::Sidecar;
 
     let mock_args = MockArgs::builder()

--- a/ai-gateway/tests/rate_limit.rs
+++ b/ai-gateway/tests/rate_limit.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 
 use ai_gateway::{
-    config::{Config, rate_limit::GlobalRateLimitConfig},
+    config::{
+        Config, helicone::HeliconeFeatures, rate_limit::GlobalRateLimitConfig,
+    },
     control_plane::types::{Key, hash_key},
     tests::{TestDefault, harness::Harness, mock::MockArgs},
 };
@@ -33,7 +35,7 @@ async fn rate_limit_capacity_enforced_impl(
     rate_limit_config: GlobalRateLimitConfig,
 ) {
     let mut config = Config::test_default();
-    config.helicone.authentication = true;
+    config.helicone.features = HeliconeFeatures::All;
     config.global.rate_limit = Some(rate_limit_config);
     let mock_args = MockArgs::builder()
         .stubs(HashMap::from([
@@ -105,7 +107,7 @@ async fn rate_limit_per_user_isolation_impl(
     rate_limit_config: GlobalRateLimitConfig,
 ) {
     let mut config = Config::test_default();
-    config.helicone.authentication = true;
+    config.helicone.features = HeliconeFeatures::All;
     config.global.rate_limit = Some(rate_limit_config);
 
     let mock_args = MockArgs::builder()
@@ -193,7 +195,7 @@ async fn rate_limit_per_user_isolation_impl(
 #[serial_test::serial]
 async fn rate_limit_disabled() {
     let mut config = Config::test_default();
-    config.helicone.authentication = true;
+    config.helicone.features = HeliconeFeatures::All;
 
     let mock_args = MockArgs::builder()
         .stubs(HashMap::from([

--- a/ai-gateway/tests/rate_limit_combinations.rs
+++ b/ai-gateway/tests/rate_limit_combinations.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, time::Duration};
 use ai_gateway::{
     config::{
         Config,
+        helicone::HeliconeFeatures,
         rate_limit::{
             GcraConfig, GlobalRateLimitConfig, LimitsConfig, RateLimitStore,
         },
@@ -119,7 +120,7 @@ async fn make_chat_request_for_router(
 #[serial_test::serial]
 async fn test_global_rate_limit_with_router_none() {
     let mut config = Config::test_default();
-    config.helicone.authentication = true;
+    config.helicone.features = HeliconeFeatures::All;
     config.global.rate_limit = Some(GlobalRateLimitConfig {
         store: RateLimitStore::InMemory,
         // 3 requests per second
@@ -192,7 +193,7 @@ async fn test_global_rate_limit_with_router_none() {
 #[serial_test::serial]
 async fn test_router_specific_with_custom_limits() {
     let mut config = Config::test_default();
-    config.helicone.authentication = true;
+    config.helicone.features = HeliconeFeatures::All;
     config.global.rate_limit = Some(GlobalRateLimitConfig {
         store: RateLimitStore::InMemory,
         limits: None,
@@ -257,7 +258,7 @@ async fn test_router_specific_with_custom_limits() {
 #[serial_test::serial]
 async fn test_global_with_custom_router_override() {
     let mut config = Config::test_default();
-    config.helicone.authentication = true;
+    config.helicone.features = HeliconeFeatures::All;
     config.global.rate_limit = Some(GlobalRateLimitConfig {
         store: RateLimitStore::InMemory,
         // 5 requests per second
@@ -323,7 +324,7 @@ async fn test_global_with_custom_router_override() {
 #[serial_test::serial]
 async fn test_router_independence_different_rate_limits() {
     let mut config = Config::test_default();
-    config.helicone.authentication = true;
+    config.helicone.features = HeliconeFeatures::All;
     config.global.rate_limit = Some(GlobalRateLimitConfig {
         store: RateLimitStore::InMemory,
         limits: None,
@@ -501,7 +502,7 @@ async fn make_chat_request_to_router(
 #[serial_test::serial]
 async fn test_multi_router_different_rate_limits_in_memory() {
     let mut config = Config::test_default();
-    config.helicone.authentication = true;
+    config.helicone.features = HeliconeFeatures::All;
     config.global.rate_limit = Some(GlobalRateLimitConfig {
         store: RateLimitStore::InMemory,
         limits: None,

--- a/ai-gateway/tests/rate_limit_monitor.rs
+++ b/ai-gateway/tests/rate_limit_monitor.rs
@@ -4,6 +4,7 @@ use ai_gateway::{
     config::{
         Config,
         balance::{BalanceConfig, BalanceConfigInner, BalanceTarget},
+        helicone::HeliconeFeatures,
         router::{RouterConfig, RouterConfigs},
     },
     discover::monitor::rate_limit::RateLimitMonitor,
@@ -23,7 +24,7 @@ use tower::Service;
 async fn rate_limit_removes_provider_from_lb_pool() {
     let mut config = Config::test_default();
     // Enable auth so that logging services are called
-    config.helicone.authentication = true;
+    config.helicone.features = HeliconeFeatures::All;
     let balance_config = BalanceConfig::from(HashMap::from([(
         EndpointType::Chat,
         BalanceConfigInner::Weighted {

--- a/ai-gateway/tests/redis_cache.rs
+++ b/ai-gateway/tests/redis_cache.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, time::Duration};
 
 use ai_gateway::{
-    config::{Config, cache::CacheStore},
+    config::{Config, cache::CacheStore, helicone::HeliconeFeatures},
     tests::{TestDefault, harness::Harness, mock::MockArgs},
 };
 use http::{Method, Request, StatusCode};
@@ -175,7 +175,7 @@ async fn cache_enabled_globally() {
 #[serial_test::serial(default_mock)]
 async fn cache_disabled_globally() {
     let mut config = Config::test_default();
-    config.helicone.authentication = false;
+    config.helicone.features = HeliconeFeatures::None;
     // Ensure cache is NOT set globally (None by default)
     config.global.cache = None;
 
@@ -301,7 +301,7 @@ async fn cache_enabled_per_router() {
     let mut config = Config::test_default();
     // Disable auth for this test since we're testing basic passthrough
     // functionality
-    config.helicone.authentication = false;
+    config.helicone.features = HeliconeFeatures::None;
     config.global.cache = None;
 
     // Create multiple routers with different cache configurations

--- a/ai-gateway/tests/single_provider.rs
+++ b/ai-gateway/tests/single_provider.rs
@@ -4,6 +4,7 @@ use ai_gateway::{
     config::{
         Config,
         balance::BalanceConfig,
+        helicone::HeliconeFeatures,
         router::{RouterConfig, RouterConfigs},
     },
     tests::{TestDefault, harness::Harness, mock::MockArgs},
@@ -21,7 +22,7 @@ async fn openai() {
     let mut config = Config::test_default();
     // Disable auth for this test since we're testing basic provider
     // functionality
-    config.helicone.authentication = false;
+    config.helicone.features = HeliconeFeatures::None;
     let mock_args = MockArgs::builder()
         .stubs(HashMap::from([
             ("success:openai:chat_completion", 1.into()),
@@ -64,7 +65,7 @@ async fn google_with_openai_request_style() {
     let mut config = Config::test_default();
     // Disable auth for this test since we're testing basic provider
     // functionality
-    config.helicone.authentication = false;
+    config.helicone.features = HeliconeFeatures::None;
     let router_config = RouterConfigs::new(HashMap::from([(
         RouterId::Default,
         RouterConfig {
@@ -130,7 +131,7 @@ async fn anthropic_with_openai_request_style() {
     let mut config = Config::test_default();
     // Disable auth for this test since we're testing basic provider
     // functionality
-    config.helicone.authentication = false;
+    config.helicone.features = HeliconeFeatures::None;
     let router_config = RouterConfigs::new(HashMap::from([(
         RouterId::Default,
         RouterConfig {
@@ -204,7 +205,7 @@ async fn ollama() {
     let mut config = Config::test_default();
     // Disable auth for this test since we're testing basic provider
     // functionality
-    config.helicone.authentication = false;
+    config.helicone.features = HeliconeFeatures::None;
     let router_config = RouterConfigs::new(HashMap::from([(
         RouterId::Default,
         RouterConfig {
@@ -254,7 +255,7 @@ async fn ollama() {
 #[serial_test::serial(default_mock)]
 async fn bedrock_with_openai_request_style() {
     let mut config = Config::test_default();
-    config.helicone.authentication = false;
+    config.helicone.features = HeliconeFeatures::None;
     let router_config = RouterConfigs::new(HashMap::from([(
         RouterId::Default,
         RouterConfig {

--- a/ai-gateway/tests/unified_api.rs
+++ b/ai-gateway/tests/unified_api.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use ai_gateway::{
-    config::Config,
+    config::{Config, helicone::HeliconeFeatures},
     tests::{TestDefault, harness::Harness, mock::MockArgs},
 };
 use http::{Method, Request, StatusCode};
@@ -16,7 +16,7 @@ async fn openai_unified_api() {
     let mut config = Config::test_default();
     // Disable auth for this test since we're testing basic passthrough
     // functionality
-    config.helicone.authentication = false;
+    config.helicone.features = HeliconeFeatures::None;
 
     let mock_args = MockArgs::builder()
         .stubs(HashMap::from([
@@ -66,7 +66,7 @@ async fn anthropic_unified_api() {
     let mut config = Config::test_default();
     // Disable auth for this test since we're testing basic passthrough
     // functionality
-    config.helicone.authentication = false;
+    config.helicone.features = HeliconeFeatures::None;
 
     let mock_args = MockArgs::builder()
         .stubs(HashMap::from([

--- a/ai-gateway/tests/weighted_balance.rs
+++ b/ai-gateway/tests/weighted_balance.rs
@@ -4,6 +4,7 @@ use ai_gateway::{
     config::{
         Config,
         balance::{BalanceConfig, BalanceConfigInner, BalanceTarget},
+        helicone::HeliconeFeatures,
         router::{RouterConfig, RouterConfigs},
     },
     endpoints::EndpointType,
@@ -22,7 +23,7 @@ use tower::Service;
 async fn weighted_balancer_anthropic_preferred() {
     let mut config = Config::test_default();
     // Disable auth for this test since we're not testing authentication
-    config.helicone.authentication = false;
+    config.helicone.features = HeliconeFeatures::None;
     let balance_config = BalanceConfig::from(HashMap::from([(
         EndpointType::Chat,
         BalanceConfigInner::Weighted {
@@ -108,7 +109,7 @@ async fn weighted_balancer_anthropic_preferred() {
 async fn weighted_balancer_openai_preferred() {
     let mut config = Config::test_default();
     // Disable auth for this test since we're not testing authentication
-    config.helicone.authentication = false;
+    config.helicone.features = HeliconeFeatures::None;
     let balance_config = BalanceConfig::from(HashMap::from([(
         EndpointType::Chat,
         BalanceConfigInner::Weighted {
@@ -194,7 +195,7 @@ async fn weighted_balancer_openai_preferred() {
 async fn weighted_balancer_anthropic_heavily_preferred() {
     let mut config = Config::test_default();
     // Disable auth for this test since we're not testing authentication
-    config.helicone.authentication = false;
+    config.helicone.features = HeliconeFeatures::None;
     let balance_config = BalanceConfig::from(HashMap::from([(
         EndpointType::Chat,
         BalanceConfigInner::Weighted {
@@ -286,7 +287,7 @@ async fn weighted_balancer_anthropic_heavily_preferred() {
 async fn weighted_balancer_equal_four_providers() {
     let mut config = Config::test_default();
     // Disable auth for this test since we're not testing authentication
-    config.helicone.authentication = false;
+    config.helicone.features = HeliconeFeatures::None;
     let balance_config = BalanceConfig::from(HashMap::from([(
         EndpointType::Chat,
         BalanceConfigInner::Weighted {
@@ -383,7 +384,7 @@ async fn weighted_balancer_equal_four_providers() {
 async fn weighted_balancer_bedrock() {
     let mut config = Config::test_default();
     // Disable auth for this test since we're not testing authentication
-    config.helicone.authentication = false;
+    config.helicone.features = HeliconeFeatures::None;
     let balance_config = BalanceConfig::from(HashMap::from([(
         EndpointType::Chat,
         BalanceConfigInner::Weighted {


### PR DESCRIPTION
this commit updates the `helicone` config with a new `helicone.features`
field to reduce confusion around the previous configuration option of
two separate boolean flags for `authentication` and `observability`.

the `features` field is an enum which prevents invalid combinations
(such as enabling observability without enabling auth).

this change is backwards compataible, the old flags will still
deserialize and will be mapped to the new enum as appropriate