### PR TITLE
task: Add named inference provider variant

### DIFF
--- a/ai-gateway/src/app_state.rs
+++ b/ai-gateway/src/app_state.rs
@@ -125,19 +125,19 @@ impl AppState {
     pub async fn get_provider_api_key_for_router(
         &self,
         router_id: &RouterId,
-        provider: InferenceProvider,
+        provider: &InferenceProvider,
     ) -> Result<Option<ProviderKey>, ProviderError> {
         let provider_keys = self.0.provider_keys.read().await;
         let provider_keys = provider_keys.get(router_id).ok_or_else(|| {
             ProviderError::ProviderKeysNotFound(router_id.clone())
         })?;
-        Ok(provider_keys.get(&provider).cloned())
+        Ok(provider_keys.get(provider).cloned())
     }
 
     pub fn get_provider_api_key_for_direct_proxy(
         &self,
-        provider: InferenceProvider,
+        provider: &InferenceProvider,
     ) -> Result<Option<ProviderKey>, ProviderError> {
-        Ok(self.0.direct_proxy_api_keys.get(&provider).cloned())
+        Ok(self.0.direct_proxy_api_keys.get(provider).cloned())
     }
 }

--- a/ai-gateway/src/config/balance.rs
+++ b/ai-gateway/src/config/balance.rs
@@ -120,9 +120,9 @@ impl BalanceConfigInner {
     pub fn providers(&self) -> IndexSet<InferenceProvider> {
         match self {
             Self::Weighted { providers } => {
-                providers.iter().map(|t| t.provider).collect()
+                providers.iter().map(|t| t.provider.clone()).collect()
             }
-            Self::Latency { providers } => providers.iter().copied().collect(),
+            Self::Latency { providers } => providers.iter().cloned().collect(),
         }
     }
 }

--- a/ai-gateway/src/config/validation.rs
+++ b/ai-gateway/src/config/validation.rs
@@ -53,7 +53,7 @@ impl Config {
                     return Err(
                         ModelMappingValidationError::ProviderNotConfigured {
                             router: router_id.clone(),
-                            provider: *provider,
+                            provider: provider.clone(),
                         },
                     );
                 }
@@ -75,7 +75,7 @@ impl Config {
                 {
                     self.can_map_model(
                         source_model,
-                        *target_provider,
+                        target_provider.clone(),
                         &target_provider_config.models,
                         router_id,
                         router_config,

--- a/ai-gateway/src/discover/provider/config.rs
+++ b/ai-gateway/src/discover/provider/config.rs
@@ -68,7 +68,7 @@ impl ConfigDiscovery<Key> {
                     app_state.clone(),
                     router_id,
                     router_config,
-                    key.provider,
+                    key.provider.clone(),
                 )
                 .await?;
                 service_map.insert(key, dispatcher);
@@ -104,19 +104,20 @@ impl ConfigDiscovery<WeightedKey> {
                 }
             };
             for target in weighted_balance_targets {
-                let weight = Weight::from(
-                    target
-                        .weight
-                        .to_f64()
-                        .ok_or(InitError::InvalidWeight(target.provider))?,
+                let weight =
+                    Weight::from(target.weight.to_f64().ok_or_else(|| {
+                        InitError::InvalidWeight(target.provider.clone())
+                    })?);
+                let key = WeightedKey::new(
+                    target.provider.clone(),
+                    *endpoint_type,
+                    weight,
                 );
-                let key =
-                    WeightedKey::new(target.provider, *endpoint_type, weight);
                 let dispatcher = Dispatcher::new(
                     app_state.clone(),
                     router_id,
                     router_config,
-                    key.provider,
+                    key.provider.clone(),
                 )
                 .await?;
                 service_map.insert(key, dispatcher);

--- a/ai-gateway/src/discover/provider/mod.rs
+++ b/ai-gateway/src/discover/provider/mod.rs
@@ -4,7 +4,7 @@ pub mod factory;
 
 use crate::{endpoints::EndpointType, types::provider::InferenceProvider};
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Key {
     pub provider: InferenceProvider,
     pub endpoint_type: EndpointType,

--- a/ai-gateway/src/discover/weighted/mod.rs
+++ b/ai-gateway/src/discover/weighted/mod.rs
@@ -4,7 +4,7 @@ use crate::{endpoints::EndpointType, types::provider::InferenceProvider};
 
 pub mod factory;
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct WeightedKey {
     pub provider: InferenceProvider,
     pub endpoint_type: EndpointType,

--- a/ai-gateway/src/dispatcher/client.rs
+++ b/ai-gateway/src/dispatcher/client.rs
@@ -106,6 +106,10 @@ impl Client {
             InferenceProvider::Ollama => {
                 Ok(Self::Ollama(OllamaClient::new(app_state, base_client)?))
             }
+            // will be implemented in future PR
+            InferenceProvider::Named(_) => {
+                Err(InitError::ProviderNotSupported(inference_provider))
+            }
         }
     }
 
@@ -118,7 +122,7 @@ impl Client {
             return Self::new_inner(app_state, inference_provider, None);
         }
         let api_key = &app_state
-            .get_provider_api_key_for_router(router_id, inference_provider)
+            .get_provider_api_key_for_router(router_id, &inference_provider)
             .await?;
 
         Self::new_inner(app_state, inference_provider, api_key.as_ref())
@@ -132,7 +136,7 @@ impl Client {
             return Self::new_inner(app_state, inference_provider, None);
         }
         let api_key = &app_state
-            .get_provider_api_key_for_direct_proxy(inference_provider)?;
+            .get_provider_api_key_for_direct_proxy(&inference_provider)?;
 
         Self::new_inner(app_state, inference_provider, api_key.as_ref())
     }
@@ -147,7 +151,7 @@ impl Client {
         // we're cheating here but this will be changed soon for cloud hosted
         // version
         let api_key = &app_state
-            .get_provider_api_key_for_direct_proxy(inference_provider)?;
+            .get_provider_api_key_for_direct_proxy(&inference_provider)?;
 
         Self::new_inner(app_state, inference_provider, api_key.as_ref())
     }

--- a/ai-gateway/src/endpoints/anthropic/messages.rs
+++ b/ai-gateway/src/endpoints/anthropic/messages.rs
@@ -27,7 +27,7 @@ impl AiRequest for CreateMessageParams {
 
     fn model(&self) -> Result<ModelId, MapperError> {
         ModelId::from_str_and_provider(
-            InferenceProvider::Anthropic,
+            &InferenceProvider::Anthropic,
             &self.model,
         )
     }

--- a/ai-gateway/src/endpoints/bedrock/converse.rs
+++ b/ai-gateway/src/endpoints/bedrock/converse.rs
@@ -29,7 +29,7 @@ impl AiRequest for ConverseInput {
     fn model(&self) -> Result<ModelId, MapperError> {
         let model =
             self.model_id.as_ref().ok_or(MapperError::InvalidRequest)?;
-        ModelId::from_str_and_provider(InferenceProvider::Bedrock, model)
+        ModelId::from_str_and_provider(&InferenceProvider::Bedrock, model)
     }
 }
 

--- a/ai-gateway/src/endpoints/google/generate_contents.rs
+++ b/ai-gateway/src/endpoints/google/generate_contents.rs
@@ -34,7 +34,7 @@ impl AiRequest for CreateChatCompletionRequestGemini {
 
     fn model(&self) -> Result<ModelId, MapperError> {
         ModelId::from_str_and_provider(
-            InferenceProvider::GoogleGemini,
+            &InferenceProvider::GoogleGemini,
             &self.0.model,
         )
     }

--- a/ai-gateway/src/endpoints/mod.rs
+++ b/ai-gateway/src/endpoints/mod.rs
@@ -80,7 +80,7 @@ impl ApiEndpoint {
 
     pub fn mapped(
         source_endpoint: ApiEndpoint,
-        target_provider: InferenceProvider,
+        target_provider: &InferenceProvider,
     ) -> Result<Self, InvalidRequestError> {
         match (source_endpoint, target_provider) {
             (Self::OpenAI(source), InferenceProvider::Anthropic) => {
@@ -99,8 +99,10 @@ impl ApiEndpoint {
                 Ok(Self::Bedrock(Bedrock::from(source)))
             }
             _ => {
-                // only openai SDK is supported for now
-                Err(InvalidRequestError::UnsupportedProvider(target_provider))
+                // Full support for named providers is coming in a future PR
+                Err(InvalidRequestError::UnsupportedProvider(
+                    target_provider.clone(),
+                ))
             }
         }
     }

--- a/ai-gateway/src/endpoints/ollama/chat_completions.rs
+++ b/ai-gateway/src/endpoints/ollama/chat_completions.rs
@@ -33,6 +33,9 @@ impl AiRequest for CreateChatCompletionRequestOllama {
     }
 
     fn model(&self) -> Result<ModelId, MapperError> {
-        ModelId::from_str_and_provider(InferenceProvider::Ollama, &self.0.model)
+        ModelId::from_str_and_provider(
+            &InferenceProvider::Ollama,
+            &self.0.model,
+        )
     }
 }

--- a/ai-gateway/src/endpoints/openai/chat_completions.rs
+++ b/ai-gateway/src/endpoints/openai/chat_completions.rs
@@ -28,7 +28,7 @@ impl AiRequest for CreateChatCompletionRequest {
     }
 
     fn model(&self) -> Result<ModelId, MapperError> {
-        ModelId::from_str_and_provider(InferenceProvider::OpenAI, &self.model)
+        ModelId::from_str_and_provider(&InferenceProvider::OpenAI, &self.model)
     }
 }
 

--- a/ai-gateway/src/error/init.rs
+++ b/ai-gateway/src/error/init.rs
@@ -62,4 +62,6 @@ pub enum InitError {
     MinioNotConfigured,
     /// Database connection error: {0}
     DatabaseConnection(sqlx::Error),
+    /// Provider not yet supported: {0}
+    ProviderNotSupported(InferenceProvider),
 }

--- a/ai-gateway/src/middleware/add_extension.rs
+++ b/ai-gateway/src/middleware/add_extension.rs
@@ -19,7 +19,7 @@ impl<S> Layer<S> for AddExtensionsLayer {
     fn layer(&self, inner: S) -> Self::Service {
         AddExtensions {
             inner,
-            inference_provider: self.inference_provider,
+            inference_provider: self.inference_provider.clone(),
             router_id: self.router_id.clone(),
         }
     }
@@ -50,7 +50,7 @@ where
 
     fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
         let extensions = req.extensions_mut();
-        extensions.insert(self.inference_provider);
+        extensions.insert(self.inference_provider.clone());
         if let Some(router_id) = self.router_id.clone() {
             extensions.insert(router_id);
         }

--- a/ai-gateway/src/middleware/mapper/anthropic.rs
+++ b/ai-gateway/src/middleware/mapper/anthropic.rs
@@ -47,18 +47,21 @@ impl
     > {
         use anthropic_ai_sdk::types::message as anthropic;
         use async_openai::types as openai;
-        let target_provider = InferenceProvider::Anthropic;
         let source_model = ModelId::from_str(&value.model)?;
         let mut target_model = self
             .model_mapper
-            .map_model(&source_model, &target_provider)?;
+            .map_model(&source_model, &InferenceProvider::Anthropic)?;
         tracing::trace!(source_model = ?source_model, target_model = ?target_model, "mapped model");
 
         // for claude 3-x, anthropic required an explicit `-latest` suffix for
         // aliases but for claude 4-x, the aliases must be implicit, ie they
         // must not have the `-latest` suffix
 
-        if let ModelId::Anthropic(model) = &mut target_model {
+        if let ModelId::ModelIdWithVersion {
+            provider: InferenceProvider::Anthropic,
+            id: model,
+        } = &mut target_model
+        {
             if model.model.contains("claude-3") {
                 model.version = Version::Latest;
             } else {

--- a/ai-gateway/src/middleware/mapper/bedrock.rs
+++ b/ai-gateway/src/middleware/mapper/bedrock.rs
@@ -42,12 +42,11 @@ impl
     > {
         use async_openai::types as openai;
         use aws_sdk_bedrockruntime::types as bedrock;
-        let target_provider = InferenceProvider::Bedrock;
         let source_model = ModelId::from_str(&value.model)?;
 
         let target_model = self
             .model_mapper
-            .map_model(&source_model, &target_provider)?;
+            .map_model(&source_model, &InferenceProvider::Bedrock)?;
 
         tracing::trace!(source_model = ?source_model, target_model = ?target_model, "mapped model");
 

--- a/ai-gateway/src/middleware/mapper/model.rs
+++ b/ai-gateway/src/middleware/mapper/model.rs
@@ -63,7 +63,9 @@ impl ModelMapper {
         let models_offered_by_target_provider = &self
             .providers_config()
             .get(target_provider)
-            .ok_or(MapperError::NoProviderConfig(*target_provider))?
+            .ok_or_else(|| {
+                MapperError::NoProviderConfig(target_provider.clone())
+            })?
             .models;
 
         let source_model_name = ModelName::from_model(source_model);
@@ -85,7 +87,7 @@ impl ModelMapper {
             if let Some(target_model) = target_model {
                 // the parsed model id here will use the "latest" version
                 return ModelId::from_str_and_provider(
-                    *target_provider,
+                    target_provider,
                     target_model.as_ref(),
                 );
             }
@@ -99,12 +101,14 @@ impl ModelMapper {
                 m.iter()
                     .find(|m| models_offered_by_target_provider.contains(*m))
             })
-            .ok_or(MapperError::NoModelMapping(
-                *target_provider,
-                source_model_name.as_ref().to_string(),
-            ))?;
+            .ok_or_else(|| {
+                MapperError::NoModelMapping(
+                    target_provider.clone(),
+                    source_model_name.as_ref().to_string(),
+                )
+            })?;
         ModelId::from_str_and_provider(
-            *target_provider,
+            target_provider,
             default_mapping.as_ref(),
         )
     }

--- a/ai-gateway/src/middleware/mapper/openai.rs
+++ b/ai-gateway/src/middleware/mapper/openai.rs
@@ -40,11 +40,10 @@ impl
     > {
         use anthropic_ai_sdk::types::message as anthropic;
         use async_openai::types as openai;
-        let target_provider = InferenceProvider::OpenAI;
         let source_model = ModelId::from_str(&value.model)?;
         let target_model = self
             .model_mapper
-            .map_model(&source_model, &target_provider)?;
+            .map_model(&source_model, &InferenceProvider::OpenAI)?;
 
         tracing::trace!(source_model = ?source_model, target_model = ?target_model, "mapped model");
         let reasoning_effort = if let Some(thinking) = value.thinking {

--- a/ai-gateway/src/middleware/response_headers.rs
+++ b/ai-gateway/src/middleware/response_headers.rs
@@ -98,7 +98,7 @@ where
         };
         if this.config.provider {
             let inference_provider =
-                response.extensions().get::<InferenceProvider>().copied();
+                response.extensions().get::<InferenceProvider>();
             if let Some(inference_provider) = inference_provider {
                 if let Ok(header_value) =
                     http::HeaderValue::from_str(inference_provider.as_ref())

--- a/ai-gateway/src/router/direct.rs
+++ b/ai-gateway/src/router/direct.rs
@@ -32,8 +32,10 @@ impl DirectProxies {
         let provider_keys = app_state.0.direct_proxy_api_keys.clone();
         for (provider, _provider_config) in app_state.config().providers.iter()
         {
-            let direct_proxy_dispatcher =
-                Dispatcher::new_direct_proxy(app_state.clone(), *provider)?;
+            let direct_proxy_dispatcher = Dispatcher::new_direct_proxy(
+                app_state.clone(),
+                provider.clone(),
+            )?;
 
             let direct_proxy = ServiceBuilder::new()
                 // TODO: should we change how global configs work for rate
@@ -49,7 +51,7 @@ impl DirectProxies {
                 // .map_err(|e| crate::error::api::Error::Box(e))
                 .service(direct_proxy_dispatcher);
 
-            direct_proxies.insert(*provider, direct_proxy);
+            direct_proxies.insert(provider.clone(), direct_proxy);
         }
         Ok(Self(Arc::new(direct_proxies)))
     }
@@ -74,8 +76,10 @@ impl DirectProxiesWithoutMapper {
         let provider_keys = app_state.0.direct_proxy_api_keys.clone();
         for (provider, _provider_config) in app_state.config().providers.iter()
         {
-            let direct_proxy_dispatcher =
-                Dispatcher::new_without_mapper(app_state.clone(), *provider)?;
+            let direct_proxy_dispatcher = Dispatcher::new_without_mapper(
+                app_state.clone(),
+                provider.clone(),
+            )?;
 
             let direct_proxy = ServiceBuilder::new()
                 // TODO: should we change how global configs work for rate
@@ -91,7 +95,7 @@ impl DirectProxiesWithoutMapper {
                 // .map_err(|e| crate::error::api::Error::Box(e))
                 .service(direct_proxy_dispatcher);
 
-            direct_proxies.insert(*provider, direct_proxy);
+            direct_proxies.insert(provider.clone(), direct_proxy);
         }
         Ok(Self(Arc::new(direct_proxies)))
     }

--- a/scripts/test/src/main.rs
+++ b/scripts/test/src/main.rs
@@ -138,9 +138,7 @@ async fn test(
     let url = match request_type {
         RequestType::Direct => {
             let provider = match model_id {
-                ModelId::OpenAI(_) => InferenceProvider::OpenAI,
-                ModelId::Anthropic(_) => InferenceProvider::Anthropic,
-                ModelId::GoogleGemini(_) => InferenceProvider::GoogleGemini,
+                ModelId::ModelIdWithVersion { provider, .. } => provider,
                 ModelId::Bedrock(_) => InferenceProvider::Bedrock,
                 ModelId::Ollama(_) => InferenceProvider::Ollama,
                 ModelId::Unknown(_) => InferenceProvider::OpenAI,


### PR DESCRIPTION
- adds a variant to the `InferenceProvider` enum that contains a string
- this will be used in upcoming work that allows us to add new, openai compatible providers via config only changes