### PR TITLE
task: add default ./config.yaml path

### DIFF
--- a/ai-gateway/src/config/mod.rs
+++ b/ai-gateway/src/config/mod.rs
@@ -28,6 +28,7 @@ use thiserror::Error;
 use crate::{error::init::InitError, types::secret::Secret};
 
 const ROUTER_ID_REGEX: &str = r"^[A-Za-z0-9_-]{1,12}$";
+const DEFAULT_CONFIG_PATH: &str = "/etc/ai-gateway/config.yaml";
 
 #[derive(Debug, Error, Display)]
 pub enum Error {
@@ -95,6 +96,10 @@ impl Config {
         let mut builder = config::Config::builder();
         if let Some(path) = config_file_path {
             builder = builder.add_source(config::File::from(path));
+        } else if std::fs::exists(DEFAULT_CONFIG_PATH).unwrap_or_default() {
+            builder = builder.add_source(config::File::from(PathBuf::from(
+                DEFAULT_CONFIG_PATH,
+            )));
         }
         builder = builder.add_source(
             config::Environment::with_prefix("AI_GATEWAY")


### PR DESCRIPTION
this PR adds a default config path of ./config.yaml to enable better DX for docker commands, eg instead of

```
docker run -it -p 8080:8080 -v ./:/helicone-config helicone/ai-gateway:main bash -c "ai-gateway --config /helicone-config/config.yaml"

```

we can now do:

```
docker run -it -p 8080:8080 -v ./{PATH_WHERE_YOUR_CONFIG_FILE_IS}:./config.yaml helicone/ai-gateway
```