### PR TITLE
refactor: Remove "default" router keyword

### DIFF
--- a/ai-gateway/config/local.yaml
+++ b/ai-gateway/config/local.yaml
@@ -8,7 +8,7 @@ helicone:
   features: all
 
 routers:
-  default:
+  my-router:
     load-balance:
       chat:
         strategy: latency

--- a/ai-gateway/config/sidecar.yaml
+++ b/ai-gateway/config/sidecar.yaml
@@ -1,5 +1,5 @@
 routers:
-  default:
+  my-router:
     load-balance:
       chat:
         strategy: latency

--- a/ai-gateway/src/config/router.rs
+++ b/ai-gateway/src/config/router.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use compact_str::CompactString;
 use derive_more::{AsMut, AsRef};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -16,22 +17,15 @@ use crate::{
     types::router::RouterId,
 };
 
-#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq, AsRef, AsMut)]
+#[derive(
+    Debug, Default, Clone, Deserialize, Serialize, Eq, PartialEq, AsRef, AsMut,
+)]
 pub struct RouterConfigs(HashMap<RouterId, RouterConfig>);
 
 impl RouterConfigs {
     #[must_use]
     pub fn new(configs: HashMap<RouterId, RouterConfig>) -> Self {
         Self(configs)
-    }
-}
-
-impl Default for RouterConfigs {
-    fn default() -> Self {
-        Self(HashMap::from([(
-            RouterId::Default,
-            RouterConfig::default(),
-        )]))
     }
 }
 
@@ -111,7 +105,7 @@ impl RouterRateLimitConfig {
 impl crate::tests::TestDefault for RouterConfigs {
     fn test_default() -> Self {
         Self(HashMap::from([(
-            RouterId::Default,
+            RouterId::Named(CompactString::new("my-router")),
             RouterConfig {
                 model_mappings: None,
                 cache: None,

--- a/ai-gateway/src/config/validation.rs
+++ b/ai-gateway/src/config/validation.rs
@@ -182,6 +182,8 @@ impl Config {
 
 #[cfg(test)]
 mod tests {
+    use compact_str::CompactString;
+
     use super::*;
 
     #[test]
@@ -212,7 +214,7 @@ mod tests {
             &source_model,
             InferenceProvider::OpenAI,
             &target_models,
-            &RouterId::Default,
+            &RouterId::Named(CompactString::new("my-router")),
             &router_config,
         );
 

--- a/ai-gateway/src/control_plane/types.rs
+++ b/ai-gateway/src/control_plane/types.rs
@@ -91,7 +91,7 @@ impl crate::tests::TestDefault for Config {
                 key_hash: key_hash.clone(),
                 owner_id: user_id.to_string(),
             }],
-            router_id: "default".to_string(),
+            router_id: "my-router".to_string(),
             router_config: "{}".to_string(),
         }
     }

--- a/ai-gateway/src/middleware/rate_limit/service.rs
+++ b/ai-gateway/src/middleware/rate_limit/service.rs
@@ -308,6 +308,8 @@ where
 mod tests {
     use std::{num::NonZeroU32, time::Duration};
 
+    use compact_str::CompactString;
+
     use super::*;
     use crate::{
         app_state::AppState,
@@ -358,9 +360,12 @@ mod tests {
         .await;
         let router_config = create_router_config(RouterRateLimitConfig::None);
 
-        let result =
-            Layer::per_router(&app_state, RouterId::Default, &router_config)
-                .await;
+        let result = Layer::per_router(
+            &app_state,
+            RouterId::Named(CompactString::new("my-router")),
+            &router_config,
+        )
+        .await;
         assert!(result.is_ok());
         assert!(matches!(result.unwrap().inner, InnerLayer::None));
     }
@@ -378,9 +383,12 @@ mod tests {
                 limits: create_test_limits(),
             });
 
-        let result =
-            Layer::per_router(&app_state, RouterId::Default, &router_config)
-                .await;
+        let result = Layer::per_router(
+            &app_state,
+            RouterId::Named(CompactString::new("my-router")),
+            &router_config,
+        )
+        .await;
         assert!(result.is_ok());
         assert!(matches!(result.unwrap().inner, InnerLayer::InMemory(_)));
     }
@@ -398,9 +406,12 @@ mod tests {
                 limits: create_test_limits(),
             });
 
-        let result =
-            Layer::per_router(&app_state, RouterId::Default, &router_config)
-                .await;
+        let result = Layer::per_router(
+            &app_state,
+            RouterId::Named(CompactString::new("my-router")),
+            &router_config,
+        )
+        .await;
         assert!(result.is_ok());
         assert!(matches!(result.unwrap().inner, InnerLayer::InMemory(_)));
     }

--- a/ai-gateway/src/router/meta.rs
+++ b/ai-gateway/src/router/meta.rs
@@ -359,13 +359,8 @@ fn extract_router_id_and_path<'a>(
             })?
             .as_str();
 
-        // Treat the special literal "default" (case-insensitive) as the default
-        // router. Anything else is considered a named router.
-        let router_id = if id_str.eq_ignore_ascii_case("default") {
-            RouterId::Default
-        } else {
-            RouterId::Named(CompactString::from(id_str))
-        };
+        // All router IDs are treated as named routers
+        let router_id = RouterId::Named(CompactString::from(id_str));
 
         // Determine the API sub-path
         let api_path = captures
@@ -488,16 +483,19 @@ mod tests {
         let url_regex = Regex::new(ROUTER_URL_REGEX).unwrap();
 
         // --- Default router id ---
-        let path_default = "/router/default";
+        let path_default = "/router/my-router";
         let expected_api_path_default = "";
         assert_eq!(
             extract_router_id_and_path(&url_regex, path_default).unwrap(),
-            (RouterId::Default, expected_api_path_default)
+            (
+                RouterId::Named(CompactString::from("my-router")),
+                expected_api_path_default
+            )
         );
 
         // Default router id with API path and query params
         let path_default_with_path_query =
-            "/router/default/chat/completions?user=test";
+            "/router/my-router/chat/completions?user=test";
         let expected_api_path_default_with_path_query = "/chat/completions";
         assert_eq!(
             extract_router_id_and_path(
@@ -505,7 +503,10 @@ mod tests {
                 path_default_with_path_query
             )
             .unwrap(),
-            (RouterId::Default, expected_api_path_default_with_path_query)
+            (
+                RouterId::Named(CompactString::from("my-router")),
+                expected_api_path_default_with_path_query
+            )
         );
 
         // --- Named router id ---

--- a/ai-gateway/src/types/router.rs
+++ b/ai-gateway/src/types/router.rs
@@ -5,13 +5,9 @@ use uuid::Uuid;
 
 use crate::config::router::RouterConfig;
 
-#[derive(
-    Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum RouterId {
-    #[default]
-    Default,
     #[serde(untagged)]
     Named(CompactString),
 }
@@ -20,7 +16,6 @@ impl AsRef<str> for RouterId {
     fn as_ref(&self) -> &str {
         match self {
             RouterId::Named(name) => name.as_str(),
-            RouterId::Default => "default",
         }
     }
 }
@@ -29,7 +24,6 @@ impl std::fmt::Display for RouterId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             RouterId::Named(name) => write!(f, "{name}"),
-            RouterId::Default => write!(f, "default"),
         }
     }
 }
@@ -55,7 +49,7 @@ mod tests {
             serde_json::from_str::<RouterId>(&serialized).unwrap();
         assert_eq!(id, deserialized);
 
-        let id = RouterId::Default;
+        let id = RouterId::Named(CompactString::new("my-router"));
         let serialized = serde_json::to_string(&id).unwrap();
         let deserialized =
             serde_json::from_str::<RouterId>(&serialized).unwrap();

--- a/ai-gateway/tests/auth.rs
+++ b/ai-gateway/tests/auth.rs
@@ -45,7 +45,7 @@ async fn require_auth_enabled_with_valid_token() {
     let request = Request::builder()
         .method(Method::POST)
         .header("authorization", "Bearer sk-helicone-test-key")
-        .uri("http://router.helicone.com/router/default/chat/completions")
+        .uri("http://router.helicone.com/router/my-router/chat/completions")
         .body(request_body)
         .unwrap();
 
@@ -98,7 +98,7 @@ async fn require_auth_enabled_without_token() {
     let request = Request::builder()
         .method(Method::POST)
         // Missing authorization header
-        .uri("http://router.helicone.com/router/default/chat/completions")
+        .uri("http://router.helicone.com/router/my-router/chat/completions")
         .body(request_body)
         .unwrap();
 
@@ -142,7 +142,7 @@ async fn require_auth_disabled_without_token() {
     let request = Request::builder()
         .method(Method::POST)
         // No authorization header, but auth is disabled
-        .uri("http://router.helicone.com/router/default/chat/completions")
+        .uri("http://router.helicone.com/router/my-router/chat/completions")
         .body(request_body)
         .unwrap();
 
@@ -186,7 +186,7 @@ async fn require_auth_disabled_with_token() {
     let request = Request::builder()
         .method(Method::POST)
         .header("authorization", "Bearer sk-helicone-test-key")
-        .uri("http://router.helicone.com/router/default/chat/completions")
+        .uri("http://router.helicone.com/router/my-router/chat/completions")
         .body(request_body)
         .unwrap();
 

--- a/ai-gateway/tests/cache.rs
+++ b/ai-gateway/tests/cache.rs
@@ -43,7 +43,7 @@ fn make_request(
 /// Test that requests are cached when enabled globally via config.
 /// This should check that requests on any of the three possible URLs
 /// (`/ai/chat/completions`, `/openai/v1/chat/completions`,
-/// `/router/default/chat/completions`) are cached. Start with the default
+/// `/router/my-router/chat/completions`) are cached. Start with the default
 /// router and then expand the test cases.
 ///
 /// In order to assert that the request is cached, we need to make sure that
@@ -73,7 +73,7 @@ async fn cache_enabled_globally() {
 
     // First request - should be a cache miss
     let request = make_request(
-        "http://router.helicone.com/router/default/chat/completions",
+        "http://router.helicone.com/router/my-router/chat/completions",
         Some(("cache-control", "max-age=3600")),
     );
     let response = harness.call(request).await.unwrap();
@@ -87,7 +87,7 @@ async fn cache_enabled_globally() {
 
     // Second request - should be a cache hit
     let request = make_request(
-        "http://router.helicone.com/router/default/chat/completions",
+        "http://router.helicone.com/router/my-router/chat/completions",
         Some(("cache-control", "max-age=3600")),
     );
     let response = harness.call(request).await.unwrap();
@@ -162,7 +162,7 @@ async fn cache_enabled_globally() {
 /// Test that requests are not cached when disabled globally via config.
 /// This should check that requests on any of the three possible URLs
 /// (`/ai/chat/completions`, `/openai/v1/chat/completions`,
-/// `/router/default/chat/completions`) are NOT cached. Start with the
+/// `/router/my-router/chat/completions`) are NOT cached. Start with the
 /// default router and then expand the test cases.
 ///
 /// In order to assert that the request is not cached, we need to
@@ -194,7 +194,7 @@ async fn cache_disabled_globally() {
     // Test default router endpoint
     // First request - should not have cache header
     let request = make_request(
-        "http://router.helicone.com/router/default/chat/completions",
+        "http://router.helicone.com/router/my-router/chat/completions",
         Some(("cache-control", "max-age=3600")),
     );
     let response = harness.call(request).await.unwrap();
@@ -206,7 +206,7 @@ async fn cache_disabled_globally() {
 
     // Second request - should still not have cache header
     let request = make_request(
-        "http://router.helicone.com/router/default/chat/completions",
+        "http://router.helicone.com/router/my-router/chat/completions",
         Some(("cache-control", "max-age=3600")),
     );
     let response = harness.call(request).await.unwrap();
@@ -273,7 +273,7 @@ async fn cache_disabled_globally() {
 /// Test that requests are cached when enabled per router via config.
 /// This should check that requests on any of the three possible URLs
 /// (`/ai/chat/completions`, `/openai/v1/chat/completions`,
-/// `/router/default/chat/completions`) are cached. Start with the default
+/// `/router/my-router/chat/completions`) are cached. Start with the default
 /// router and then expand the test cases.
 ///
 /// In order to assert that the request is cached, we need to
@@ -329,7 +329,7 @@ async fn cache_enabled_per_router() {
             },
         ),
         (
-            RouterId::Default,
+            RouterId::Named(CompactString::new("my-router")),
             RouterConfig {
                 cache: None, // Default router also has no cache
                 load_balance:
@@ -408,7 +408,7 @@ async fn cache_enabled_per_router() {
 
     // Test 3: Default router (no cache)
     let request = make_request(
-        "http://router.helicone.com/router/default/chat/completions",
+        "http://router.helicone.com/router/my-router/chat/completions",
         Some(("cache-control", "max-age=3600")),
     );
     let response = harness.call(request).await.unwrap();
@@ -420,7 +420,7 @@ async fn cache_enabled_per_router() {
     );
 
     let request = make_request(
-        "http://router.helicone.com/router/default/chat/completions",
+        "http://router.helicone.com/router/my-router/chat/completions",
         Some(("cache-control", "max-age=3600")),
     );
     let response = harness.call(request).await.unwrap();

--- a/ai-gateway/tests/health_monitor.rs
+++ b/ai-gateway/tests/health_monitor.rs
@@ -12,6 +12,7 @@ use ai_gateway::{
     tests::{TestDefault, harness::Harness, mock::MockArgs},
     types::{provider::InferenceProvider, router::RouterId},
 };
+use compact_str::CompactString;
 use http::{Method, Request};
 use http_body_util::BodyExt;
 use nonempty_collections::nes;
@@ -45,7 +46,7 @@ async fn errors_remove_provider_from_lb_pool() {
         },
     )]));
     config.routers = RouterConfigs::new(HashMap::from([(
-        RouterId::Default,
+        RouterId::Named(CompactString::new("my-router")),
         RouterConfig {
             load_balance: balance_config,
             ..Default::default()
@@ -89,7 +90,7 @@ async fn errors_remove_provider_from_lb_pool() {
             .method(Method::POST)
             .header("authorization", "Bearer sk-helicone-test-key")
             // default router
-            .uri("http://router.helicone.com/router/default/chat/completions")
+            .uri("http://router.helicone.com/router/my-router/chat/completions")
             .body(request_body)
             .unwrap();
         let response = harness.call(request).await.unwrap();

--- a/ai-gateway/tests/load_balance.rs
+++ b/ai-gateway/tests/load_balance.rs
@@ -11,6 +11,7 @@ use ai_gateway::{
     tests::{TestDefault, harness::Harness, mock::MockArgs},
     types::{provider::InferenceProvider, router::RouterId},
 };
+use compact_str::CompactString;
 use http::{Method, Request, StatusCode};
 use nonempty_collections::nes;
 use serde_json::json;
@@ -18,7 +19,7 @@ use tower::Service;
 
 fn p2c_config_openai_anthropic_google() -> RouterConfigs {
     RouterConfigs::new(HashMap::from([(
-        RouterId::Default,
+        RouterId::Named(CompactString::new("my-router")),
         RouterConfig {
             load_balance: BalanceConfig(HashMap::from([(
                 EndpointType::Chat,
@@ -81,7 +82,7 @@ async fn openai_slow() {
         let request = Request::builder()
             .method(Method::POST)
             // default router
-            .uri("http://router.helicone.com/router/default/chat/completions")
+            .uri("http://router.helicone.com/router/my-router/chat/completions")
             .body(request_body)
             .unwrap();
         let response = harness.call(request).await.unwrap();
@@ -132,7 +133,7 @@ async fn anthropic_slow() {
         let request = Request::builder()
             .method(Method::POST)
             // default router
-            .uri("http://router.helicone.com/router/default/chat/completions")
+            .uri("http://router.helicone.com/router/my-router/chat/completions")
             .body(request_body)
             .unwrap();
         let response = harness.call(request).await.unwrap();

--- a/ai-gateway/tests/logger.rs
+++ b/ai-gateway/tests/logger.rs
@@ -45,7 +45,7 @@ async fn request_response_logger_authenticated() {
     let request = Request::builder()
         .method(Method::POST)
         .header("authorization", "Bearer sk-helicone-test-key")
-        .uri("http://router.helicone.com/router/default/chat/completions")
+        .uri("http://router.helicone.com/router/my-router/chat/completions")
         .body(request_body)
         .unwrap();
     let response = harness.call(request).await.unwrap();
@@ -97,7 +97,7 @@ async fn authenticated_sidecar() {
     let request = Request::builder()
         .method(Method::POST)
         .header("authorization", "Bearer sk-helicone-test-key")
-        .uri("http://router.helicone.com/router/default/chat/completions")
+        .uri("http://router.helicone.com/router/my-router/chat/completions")
         .body(request_body)
         .unwrap();
     let response = harness.call(request).await.unwrap();
@@ -148,7 +148,7 @@ async fn unauthenticated_sidecar() {
     let request = Request::builder()
         .method(Method::POST)
         .header("authorization", "Bearer sk-helicone-test-key")
-        .uri("http://router.helicone.com/router/default/chat/completions")
+        .uri("http://router.helicone.com/router/my-router/chat/completions")
         .body(request_body)
         .unwrap();
     let response = harness.call(request).await.unwrap();
@@ -191,7 +191,7 @@ async fn request_response_logger_unauthenticated() {
     let request = Request::builder()
         .method(Method::POST)
         // No authorization header when auth is not required
-        .uri("http://router.helicone.com/router/default/chat/completions")
+        .uri("http://router.helicone.com/router/my-router/chat/completions")
         .body(request_body)
         .unwrap();
     let response = harness.call(request).await.unwrap();
@@ -235,7 +235,7 @@ async fn request_response_logger_unauthenticated_sidecar() {
     let request = Request::builder()
         .method(Method::POST)
         // No authorization header when auth is not required
-        .uri("http://router.helicone.com/router/default/chat/completions")
+        .uri("http://router.helicone.com/router/my-router/chat/completions")
         .body(request_body)
         .unwrap();
     let response = harness.call(request).await.unwrap();

--- a/ai-gateway/tests/rate_limit.rs
+++ b/ai-gateway/tests/rate_limit.rs
@@ -281,7 +281,7 @@ async fn make_chat_request(
     let request = Request::builder()
         .method(Method::POST)
         .header("authorization", auth_header)
-        .uri("http://router.helicone.com/router/default/chat/completions")
+        .uri("http://router.helicone.com/router/my-router/chat/completions")
         .body(request_body)
         .unwrap();
 

--- a/ai-gateway/tests/rate_limit_combinations.rs
+++ b/ai-gateway/tests/rate_limit_combinations.rs
@@ -59,7 +59,7 @@ async fn make_chat_request(
     let request = Request::builder()
         .method(Method::POST)
         .header("authorization", auth_header)
-        .uri("http://router.helicone.com/router/default/chat/completions")
+        .uri("http://router.helicone.com/router/my-router/chat/completions")
         .body(request_body)
         .unwrap();
 
@@ -94,10 +94,6 @@ async fn make_chat_request_for_router(
         RouterId::Named(name) => {
             format!("http://router.helicone.com/router/{name}/chat/completions")
         }
-        RouterId::Default => {
-            "http://router.helicone.com/router/default/chat/completions"
-                .to_string()
-        }
     };
 
     let request_body = axum_core::body::Body::from(body_bytes);
@@ -130,7 +126,7 @@ async fn test_global_rate_limit_with_router_none() {
 
     // Router doesn't override rate limiting
     config.routers = RouterConfigs::new(HashMap::from([(
-        RouterId::Default,
+        RouterId::Named(CompactString::new("my-router")),
         create_router_config(RouterRateLimitConfig::None),
     )]));
 
@@ -202,7 +198,7 @@ async fn test_router_specific_with_custom_limits() {
 
     // Router provides its own custom rate limits
     config.routers = RouterConfigs::new(HashMap::from([(
-        RouterId::Default,
+        RouterId::Named(CompactString::new("my-router")),
         RouterConfig {
             rate_limit: RouterRateLimitConfig::Custom {
                 store: Some(RateLimitStore::InMemory),
@@ -268,7 +264,7 @@ async fn test_global_with_custom_router_override() {
     config.rate_limit_store = RateLimitStore::InMemory;
     // Router overrides with stricter custom limits
     config.routers = RouterConfigs::new(HashMap::from([(
-        RouterId::Default,
+        RouterId::Named(CompactString::new("my-router")),
         RouterConfig {
             rate_limit: RouterRateLimitConfig::Custom {
                 store: Some(RateLimitStore::InMemory),
@@ -363,7 +359,7 @@ async fn test_router_independence_different_rate_limits() {
             },
         ),
         (
-            RouterId::Default,
+            RouterId::Named(CompactString::new("my-router")),
             RouterConfig {
                 rate_limit: RouterRateLimitConfig::None, // No rate limiting
                 load_balance:
@@ -467,10 +463,6 @@ async fn make_chat_request_to_router(
         RouterId::Named(name) => {
             format!("http://router.helicone.com/router/{name}/chat/completions")
         }
-        RouterId::Default => {
-            "http://router.helicone.com/router/default/chat/completions"
-                .to_string()
-        }
     };
 
     let request = Request::builder()
@@ -512,7 +504,7 @@ async fn test_multi_router_different_rate_limits_in_memory() {
     config.rate_limit_store = RateLimitStore::InMemory;
     let router_a_id = RouterId::Named(CompactString::from("router-a"));
     let router_b_id = RouterId::Named(CompactString::from("router-b"));
-    let router_c_id = RouterId::Default;
+    let router_c_id = RouterId::Named(CompactString::new("my-router"));
 
     // Create multiple routers with different rate limit configurations
     config.routers = RouterConfigs::new(HashMap::from([

--- a/ai-gateway/tests/rate_limit_monitor.rs
+++ b/ai-gateway/tests/rate_limit_monitor.rs
@@ -12,6 +12,7 @@ use ai_gateway::{
     tests::{TestDefault, harness::Harness, mock::MockArgs},
     types::{provider::InferenceProvider, router::RouterId},
 };
+use compact_str::CompactString;
 use http::{Method, Request};
 use http_body_util::BodyExt;
 use nonempty_collections::nes;
@@ -41,7 +42,7 @@ async fn rate_limit_removes_provider_from_lb_pool() {
         },
     )]));
     config.routers = RouterConfigs::new(HashMap::from([(
-        RouterId::Default,
+        RouterId::Named(CompactString::new("my-router")),
         RouterConfig {
             load_balance: balance_config,
             ..Default::default()
@@ -98,7 +99,7 @@ async fn rate_limit_removes_provider_from_lb_pool() {
         let request = Request::builder()
             .method(Method::POST)
             .header("authorization", "Bearer sk-helicone-test-key")
-            .uri("http://router.helicone.com/router/default/chat/completions")
+            .uri("http://router.helicone.com/router/my-router/chat/completions")
             .body(request_body)
             .unwrap();
         let response = harness.call(request).await.unwrap();
@@ -127,7 +128,7 @@ async fn rate_limit_removes_provider_from_lb_pool() {
         let request = Request::builder()
             .method(Method::POST)
             .header("authorization", "Bearer sk-helicone-test-key")
-            .uri("http://router.helicone.com/router/default/chat/completions")
+            .uri("http://router.helicone.com/router/my-router/chat/completions")
             .body(request_body)
             .unwrap();
         let response = harness.call(request).await.unwrap();

--- a/ai-gateway/tests/redis_cache.rs
+++ b/ai-gateway/tests/redis_cache.rs
@@ -43,7 +43,7 @@ fn make_request(
 /// Test that requests are cached when enabled globally via config.
 /// This should check that requests on any of the three possible URLs
 /// (`/ai/chat/completions`, `/openai/v1/chat/completions`,
-/// `/router/default/chat/completions`) are cached. Start with the default
+/// `/router/my-router/chat/completions`) are cached. Start with the default
 /// router and then expand the test cases.
 ///
 /// In order to assert that the request is cached, we need to make sure that
@@ -77,7 +77,7 @@ async fn cache_enabled_globally() {
 
     // First request - should be a cache miss
     let request = make_request(
-        "http://router.helicone.com/router/default/chat/completions",
+        "http://router.helicone.com/router/my-router/chat/completions",
         Some(("cache-control", "max-age=3600")),
     );
     let response = harness.call(request).await.unwrap();
@@ -91,7 +91,7 @@ async fn cache_enabled_globally() {
 
     // Second request - should be a cache hit
     let request = make_request(
-        "http://router.helicone.com/router/default/chat/completions",
+        "http://router.helicone.com/router/my-router/chat/completions",
         Some(("cache-control", "max-age=3600")),
     );
     let response = harness.call(request).await.unwrap();
@@ -166,7 +166,7 @@ async fn cache_enabled_globally() {
 /// Test that requests are not cached when disabled globally via config.
 /// This should check that requests on any of the three possible URLs
 /// (`/ai/chat/completions`, `/openai/v1/chat/completions`,
-/// `/router/default/chat/completions`) are NOT cached. Start with the
+/// `/router/my-router/chat/completions`) are NOT cached. Start with the
 /// default router and then expand the test cases.
 ///
 /// In order to assert that the request is not cached, we need to
@@ -198,7 +198,7 @@ async fn cache_disabled_globally() {
     // Test default router endpoint
     // First request - should not have cache header
     let request = make_request(
-        "http://router.helicone.com/router/default/chat/completions",
+        "http://router.helicone.com/router/my-router/chat/completions",
         Some(("cache-control", "max-age=3600")),
     );
     let response = harness.call(request).await.unwrap();
@@ -210,7 +210,7 @@ async fn cache_disabled_globally() {
 
     // Second request - should still not have cache header
     let request = make_request(
-        "http://router.helicone.com/router/default/chat/completions",
+        "http://router.helicone.com/router/my-router/chat/completions",
         Some(("cache-control", "max-age=3600")),
     );
     let response = harness.call(request).await.unwrap();
@@ -277,7 +277,7 @@ async fn cache_disabled_globally() {
 /// Test that requests are cached when enabled per router via config.
 /// This should check that requests on any of the three possible URLs
 /// (`/ai/chat/completions`, `/openai/v1/chat/completions`,
-/// `/router/default/chat/completions`) are cached. Start with the default
+/// `/router/my-router/chat/completions`) are cached. Start with the default
 /// router and then expand the test cases.
 ///
 /// In order to assert that the request is cached, we need to
@@ -333,7 +333,7 @@ async fn cache_enabled_per_router() {
             },
         ),
         (
-            RouterId::Default,
+            RouterId::Named(CompactString::new("my-router")),
             RouterConfig {
                 cache: None, // Default router also has no cache
                 load_balance:
@@ -412,7 +412,7 @@ async fn cache_enabled_per_router() {
 
     // Test 3: Default router (no cache)
     let request = make_request(
-        "http://router.helicone.com/router/default/chat/completions",
+        "http://router.helicone.com/router/my-router/chat/completions",
         Some(("cache-control", "max-age=3600")),
     );
     let response = harness.call(request).await.unwrap();
@@ -424,7 +424,7 @@ async fn cache_enabled_per_router() {
     );
 
     let request = make_request(
-        "http://router.helicone.com/router/default/chat/completions",
+        "http://router.helicone.com/router/my-router/chat/completions",
         Some(("cache-control", "max-age=3600")),
     );
     let response = harness.call(request).await.unwrap();

--- a/ai-gateway/tests/redis_rate_limit_combinations.rs
+++ b/ai-gateway/tests/redis_rate_limit_combinations.rs
@@ -60,7 +60,7 @@ async fn make_chat_request(
     let request = Request::builder()
         .method(Method::POST)
         .header("authorization", auth_header)
-        .uri("http://router.helicone.com/router/default/chat/completions")
+        .uri("http://router.helicone.com/router/my-router/chat/completions")
         .body(request_body)
         .unwrap();
 
@@ -94,10 +94,6 @@ async fn make_chat_request_for_router(
     let uri = match router_id {
         RouterId::Named(name) => {
             format!("http://router.helicone.com/router/{name}/chat/completions")
-        }
-        RouterId::Default => {
-            "http://router.helicone.com/router/default/chat/completions"
-                .to_string()
         }
     };
 
@@ -136,7 +132,7 @@ async fn test_global_rate_limit_with_router_none() {
 
     // Router doesn't override rate limiting
     config.routers = RouterConfigs::new(HashMap::from([(
-        RouterId::Default,
+        RouterId::Named(CompactString::new("my-router")),
         create_router_config(RouterRateLimitConfig::None),
     )]));
 
@@ -211,7 +207,7 @@ async fn test_router_specific_with_custom_limits() {
 
     // Router provides its own custom rate limits
     config.routers = RouterConfigs::new(HashMap::from([(
-        RouterId::Default,
+        RouterId::Named(CompactString::new("my-router")),
         RouterConfig {
             rate_limit: RouterRateLimitConfig::Custom {
                 store: Some(RateLimitStore::Redis(RedisConfig {
@@ -286,7 +282,7 @@ async fn test_global_with_custom_router_override() {
 
     // Router overrides with stricter custom limits
     config.routers = RouterConfigs::new(HashMap::from([(
-        RouterId::Default,
+        RouterId::Named(CompactString::new("my-router")),
         RouterConfig {
             rate_limit: RouterRateLimitConfig::Custom {
                 store: Some(RateLimitStore::Redis(RedisConfig {
@@ -400,7 +396,7 @@ async fn test_router_independence_different_rate_limits() {
             },
         ),
         (
-            RouterId::Default,
+            RouterId::Named(CompactString::new("my-router")),
             RouterConfig {
                 rate_limit: RouterRateLimitConfig::None, // No rate limiting
                 load_balance:
@@ -504,10 +500,6 @@ async fn make_chat_request_to_router(
         RouterId::Named(name) => {
             format!("http://router.helicone.com/router/{name}/chat/completions")
         }
-        RouterId::Default => {
-            "http://router.helicone.com/router/default/chat/completions"
-                .to_string()
-        }
     };
 
     let request = Request::builder()
@@ -552,7 +544,7 @@ async fn test_multi_router_different_rate_limits_in_memory() {
     });
     let router_a_id = RouterId::Named(CompactString::from("router-a"));
     let router_b_id = RouterId::Named(CompactString::from("router-b"));
-    let router_c_id = RouterId::Default;
+    let router_c_id = RouterId::Named(CompactString::new("my-router"));
 
     // Create multiple routers with different rate limit configurations
     config.routers = RouterConfigs::new(HashMap::from([

--- a/ai-gateway/tests/retries.rs
+++ b/ai-gateway/tests/retries.rs
@@ -11,6 +11,7 @@ use ai_gateway::{
     tests::{TestDefault, harness::Harness, mock::MockArgs},
     types::router::RouterId,
 };
+use compact_str::CompactString;
 use http::{Method, Request, StatusCode};
 use http_body_util::BodyExt;
 use serde_json::json;
@@ -79,7 +80,7 @@ async fn router() {
     // functionality
     config.helicone.features = HeliconeFeatures::All;
     let router_configs = RouterConfigs::new(HashMap::from([(
-        RouterId::Default,
+        RouterId::Named(CompactString::new("my-router")),
         RouterConfig {
             load_balance: BalanceConfig::openai_chat(),
             retries: Some(RetryConfig::test_default()),
@@ -120,7 +121,7 @@ async fn router() {
     let request = Request::builder()
         .method(Method::POST)
         // Route to the fake endpoint through the default router
-        .uri("http://router.helicone.com/router/default/chat/completions")
+        .uri("http://router.helicone.com/router/my-router/chat/completions")
         .header("content-type", "application/json")
         .header("authorization", "Bearer sk-helicone-test-key")
         .body(request_body)

--- a/ai-gateway/tests/single_provider.rs
+++ b/ai-gateway/tests/single_provider.rs
@@ -10,6 +10,7 @@ use ai_gateway::{
     tests::{TestDefault, harness::Harness, mock::MockArgs},
     types::router::RouterId,
 };
+use compact_str::CompactString;
 use http::{Method, Request, StatusCode};
 use serde_json::json;
 use tower::Service;
@@ -50,7 +51,7 @@ async fn openai() {
     let request = Request::builder()
         .method(Method::POST)
         // default router
-        .uri("http://router.helicone.com/router/default/chat/completions")
+        .uri("http://router.helicone.com/router/my-router/chat/completions")
         .body(request_body)
         .unwrap();
     let response = harness.call(request).await.unwrap();
@@ -67,7 +68,7 @@ async fn google_with_openai_request_style() {
     // functionality
     config.helicone.features = HeliconeFeatures::None;
     let router_config = RouterConfigs::new(HashMap::from([(
-        RouterId::Default,
+        RouterId::Named(CompactString::new("my-router")),
         RouterConfig {
             load_balance: BalanceConfig::google_gemini(),
             ..Default::default()
@@ -98,7 +99,7 @@ async fn google_with_openai_request_style() {
     let request = Request::builder()
         .method(Method::POST)
         // default router
-        .uri("http://router.helicone.com/router/default/chat/completions")
+        .uri("http://router.helicone.com/router/my-router/chat/completions")
         .body(request_body)
         .unwrap();
     let response = harness.call(request).await.unwrap();
@@ -116,7 +117,7 @@ async fn google_with_openai_request_style() {
     let request = Request::builder()
         .method(Method::POST)
         // default router
-        .uri("http://router.helicone.com/router/default/chat/completions")
+        .uri("http://router.helicone.com/router/my-router/chat/completions")
         .body(request_body)
         .unwrap();
     let response = harness.call(request).await.unwrap();
@@ -133,7 +134,7 @@ async fn anthropic_with_openai_request_style() {
     // functionality
     config.helicone.features = HeliconeFeatures::None;
     let router_config = RouterConfigs::new(HashMap::from([(
-        RouterId::Default,
+        RouterId::Named(CompactString::new("my-router")),
         RouterConfig {
             load_balance: BalanceConfig::anthropic_chat(),
             ..Default::default()
@@ -168,7 +169,7 @@ async fn anthropic_with_openai_request_style() {
     let request = Request::builder()
         .method(Method::POST)
         // default router
-        .uri("http://router.helicone.com/router/default/chat/completions")
+        .uri("http://router.helicone.com/router/my-router/chat/completions")
         .body(request_body)
         .unwrap();
     let response = harness.call(request).await.unwrap();
@@ -190,7 +191,7 @@ async fn anthropic_with_openai_request_style() {
     let request = Request::builder()
         .method(Method::POST)
         // default router
-        .uri("http://router.helicone.com/router/default/chat/completions")
+        .uri("http://router.helicone.com/router/my-router/chat/completions")
         .body(request_body)
         .unwrap();
     let response = harness.call(request).await.unwrap();
@@ -207,7 +208,7 @@ async fn ollama() {
     // functionality
     config.helicone.features = HeliconeFeatures::None;
     let router_config = RouterConfigs::new(HashMap::from([(
-        RouterId::Default,
+        RouterId::Named(CompactString::new("my-router")),
         RouterConfig {
             load_balance: BalanceConfig::ollama_chat(),
             ..Default::default()
@@ -242,7 +243,7 @@ async fn ollama() {
     let request = Request::builder()
         .method(Method::POST)
         // default router
-        .uri("http://router.helicone.com/router/default/chat/completions")
+        .uri("http://router.helicone.com/router/my-router/chat/completions")
         .body(request_body)
         .unwrap();
     let response = harness.call(request).await.unwrap();
@@ -257,7 +258,7 @@ async fn bedrock_with_openai_request_style() {
     let mut config = Config::test_default();
     config.helicone.features = HeliconeFeatures::None;
     let router_config = RouterConfigs::new(HashMap::from([(
-        RouterId::Default,
+        RouterId::Named(CompactString::new("my-router")),
         RouterConfig {
             load_balance: BalanceConfig::bedrock(),
             ..Default::default()
@@ -291,7 +292,7 @@ async fn bedrock_with_openai_request_style() {
     let request = Request::builder()
         .method(Method::POST)
         // default router
-        .uri("http://router.helicone.com/router/default/chat/completions")
+        .uri("http://router.helicone.com/router/my-router/chat/completions")
         .body(request_body)
         .unwrap();
     let response = harness.call(request).await.unwrap();
@@ -306,7 +307,7 @@ async fn mistral() {
     // functionality
     config.helicone.features = HeliconeFeatures::None;
     let router_config = RouterConfigs::new(HashMap::from([(
-        RouterId::Default,
+        RouterId::Named(CompactString::new("my-router")),
         RouterConfig {
             load_balance: BalanceConfig::mistral(),
             ..Default::default()
@@ -340,7 +341,7 @@ async fn mistral() {
     let request = Request::builder()
         .method(Method::POST)
         // default router
-        .uri("http://router.helicone.com/router/default/chat/completions")
+        .uri("http://router.helicone.com/router/my-router/chat/completions")
         .body(request_body)
         .unwrap();
     let response = harness.call(request).await.unwrap();

--- a/ai-gateway/tests/weighted_balance.rs
+++ b/ai-gateway/tests/weighted_balance.rs
@@ -11,6 +11,7 @@ use ai_gateway::{
     tests::{TestDefault, harness::Harness, mock::MockArgs},
     types::{provider::InferenceProvider, router::RouterId},
 };
+use compact_str::CompactString;
 use http::{Method, Request, StatusCode};
 use http_body_util::BodyExt;
 use nonempty_collections::nes;
@@ -40,7 +41,7 @@ async fn weighted_balancer_anthropic_preferred() {
         },
     )]));
     config.routers = RouterConfigs::new(HashMap::from([(
-        RouterId::Default,
+        RouterId::Named(CompactString::new("my-router")),
         RouterConfig {
             load_balance: balance_config,
             ..Default::default()
@@ -90,7 +91,7 @@ async fn weighted_balancer_anthropic_preferred() {
         let request = Request::builder()
             .method(Method::POST)
             // default router
-            .uri("http://router.helicone.com/router/default/chat/completions")
+            .uri("http://router.helicone.com/router/my-router/chat/completions")
             .body(request_body)
             .unwrap();
         let response = harness.call(request).await.unwrap();
@@ -126,7 +127,7 @@ async fn weighted_balancer_openai_preferred() {
         },
     )]));
     config.routers = RouterConfigs::new(HashMap::from([(
-        RouterId::Default,
+        RouterId::Named(CompactString::new("my-router")),
         RouterConfig {
             load_balance: balance_config,
             ..Default::default()
@@ -176,7 +177,7 @@ async fn weighted_balancer_openai_preferred() {
         let request = Request::builder()
             .method(Method::POST)
             // default router
-            .uri("http://router.helicone.com/router/default/chat/completions")
+            .uri("http://router.helicone.com/router/my-router/chat/completions")
             .body(request_body)
             .unwrap();
         let response = harness.call(request).await.unwrap();
@@ -212,7 +213,7 @@ async fn weighted_balancer_anthropic_heavily_preferred() {
         },
     )]));
     config.routers = RouterConfigs::new(HashMap::from([(
-        RouterId::Default,
+        RouterId::Named(CompactString::new("my-router")),
         RouterConfig {
             load_balance: balance_config,
             ..Default::default()
@@ -268,7 +269,7 @@ async fn weighted_balancer_anthropic_heavily_preferred() {
         let request = Request::builder()
             .method(Method::POST)
             // default router
-            .uri("http://router.helicone.com/router/default/chat/completions")
+            .uri("http://router.helicone.com/router/my-router/chat/completions")
             .body(request_body)
             .unwrap();
         let response = harness.call(request).await.unwrap();
@@ -312,7 +313,7 @@ async fn weighted_balancer_equal_four_providers() {
         },
     )]));
     config.routers = RouterConfigs::new(HashMap::from([(
-        RouterId::Default,
+        RouterId::Named(CompactString::new("my-router")),
         RouterConfig {
             load_balance: balance_config,
             ..Default::default()
@@ -365,7 +366,7 @@ async fn weighted_balancer_equal_four_providers() {
         let request = Request::builder()
             .method(Method::POST)
             // default router
-            .uri("http://router.helicone.com/router/default/chat/completions")
+            .uri("http://router.helicone.com/router/my-router/chat/completions")
             .body(request_body)
             .unwrap();
         let response = harness.call(request).await.unwrap();
@@ -409,7 +410,7 @@ async fn weighted_balancer_bedrock() {
         },
     )]));
     config.routers = RouterConfigs::new(HashMap::from([(
-        RouterId::Default,
+        RouterId::Named(CompactString::new("my-router")),
         RouterConfig {
             load_balance: balance_config,
             ..Default::default()
@@ -462,7 +463,7 @@ async fn weighted_balancer_bedrock() {
         let request = Request::builder()
             .method(Method::POST)
             // default router
-            .uri("http://router.helicone.com/router/default/chat/completions")
+            .uri("http://router.helicone.com/router/my-router/chat/completions")
             .body(request_body)
             .unwrap();
         let response = harness.call(request).await.unwrap();

--- a/crates/mock-server/src/routes/jawn.rs
+++ b/crates/mock-server/src/routes/jawn.rs
@@ -99,7 +99,7 @@ fn mock_auth() -> ai_gateway::control_plane::types::Config {
             key_hash: key_hash,
             owner_id: user_id,
         }],
-        router_id: "default".to_string(),
+        router_id: "my-router".to_string(),
         router_config: "{}".to_string(),
     }
 }


### PR DESCRIPTION
this commit removes the `default` keyword from the routers. This was originally created before @Cole’s suggestion for the unified API endpoint (/ai), which I think serves a better purpose of what the "default" router was originally intended to do which is provide an endpoint on the gateway that's usable without any custom configuration by the user