### PR TITLE
fix: return 429 errors in OpenAI format

### DIFF
--- a/ai-gateway/src/app.rs
+++ b/ai-gateway/src/app.rs
@@ -210,7 +210,11 @@ impl App {
             .global
             .rate_limit
             .as_ref()
-            .and_then(|rl| rl.global_limiter().map(Arc::new));
+            .map(|rl| {
+                crate::config::rate_limit::limiter_config(&rl.limits)
+                    .map(Arc::new)
+            })
+            .transpose()?;
 
         let direct_proxy_api_keys =
             ProviderKeys::from_env_direct_proxy(&config.providers)

--- a/ai-gateway/src/config/mod.rs
+++ b/ai-gateway/src/config/mod.rs
@@ -54,11 +54,11 @@ pub enum DeploymentTarget {
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
-pub struct GlobalConfig {
+pub struct MiddlewareConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cache: Option<self::cache::CacheConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub rate_limit: Option<self::rate_limit::GlobalRateLimitConfig>,
+    pub rate_limit: Option<self::rate_limit::RateLimitConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retries: Option<self::retry::RetryConfig>,
 }
@@ -85,7 +85,7 @@ pub struct Config {
     pub cache_store: self::cache::CacheStore,
     pub rate_limit_store: self::rate_limit::RateLimitStore,
     /// Global middleware configuration, e.g. rate limiting, caching, etc.
-    pub global: GlobalConfig,
+    pub global: MiddlewareConfig,
     pub routers: self::router::RouterConfigs,
 }
 
@@ -176,12 +176,10 @@ impl crate::tests::TestDefault for Config {
             level: "info,ai_gateway=trace".to_string(),
             ..Default::default()
         };
-        let middleware = GlobalConfig {
-            cache: Some(self::cache::CacheConfig::test_default()),
-            rate_limit: Some(
-                self::rate_limit::GlobalRateLimitConfig::test_default(),
-            ),
-            retries: Some(self::retry::RetryConfig::test_default()),
+        let middleware = MiddlewareConfig {
+            cache: None,
+            rate_limit: None,
+            retries: None,
         };
         Config {
             telemetry,

--- a/ai-gateway/src/discover/monitor/metrics.rs
+++ b/ai-gateway/src/discover/monitor/metrics.rs
@@ -29,16 +29,15 @@ impl EndpointMetricsRegistry {
 
     pub fn new(config: &Config) -> Self {
         let mut endpoint_health_metrics = HashMap::default();
-        tracing::info!(
-            "Initializing endpoint metrics for providers: {:?}",
-            config.providers.keys()
+        tracing::debug!(
+            providers = ?config.providers.keys(),
+            "Initializing endpoint metrics for providers"
         );
         for provider in config.providers.keys() {
-            tracing::info!(
-                "Initializing endpoint metrics for provider: {:?} and \
-                 endpoints: {:?}",
-                provider,
-                provider.endpoints()
+            tracing::trace!(
+                provider = ?provider,
+                endpoints = ?provider.endpoints(),
+                "Initializing endpoint metrics for provider"
             );
             for endpoint in provider.endpoints() {
                 endpoint_health_metrics

--- a/ai-gateway/src/main.rs
+++ b/ai-gateway/src/main.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, time::Duration};
 
 use ai_gateway::{
     app::App,
@@ -100,6 +100,8 @@ fn init_telemetry(
 }
 
 async fn run_app(config: Config) -> Result<(), RuntimeError> {
+    // 5 mins
+    const CLEANUP_INTERVAL: Duration = Duration::from_secs(60 * 5);
     let mut shutting_down = false;
     let helicone_config = config.helicone.clone();
     let app = App::new(config).await?;
@@ -109,10 +111,10 @@ async fn run_app(config: Config) -> Result<(), RuntimeError> {
     let control_plane_state = app.state.0.control_plane_state.clone();
 
     let rate_limiting_cleanup_service =
-        config.global.rate_limit.as_ref().map(|rl| {
+        config.global.rate_limit.as_ref().map(|_| {
             rate_limit::cleanup::GarbageCollector::new(
                 app.state.clone(),
-                rl.cleanup_interval(),
+                CLEANUP_INTERVAL,
             )
         });
 

--- a/ai-gateway/src/middleware/cache/optional.rs
+++ b/ai-gateway/src/middleware/cache/optional.rs
@@ -118,11 +118,15 @@ where
         }
     }
 
+    #[tracing::instrument(name = "opt_cache", skip_all)]
     fn call(&mut self, req: Request) -> Self::Future {
         match self {
-            Service::Enabled { service } => ResponseFuture::Enabled {
-                future: service.call(req),
-            },
+            Service::Enabled { service } => {
+                tracing::trace!("cache middleware enabled");
+                ResponseFuture::Enabled {
+                    future: service.call(req),
+                }
+            }
             Service::Disabled { service } => ResponseFuture::Disabled {
                 future: service.call(req),
             },

--- a/ai-gateway/src/middleware/rate_limit/redis_service.rs
+++ b/ai-gateway/src/middleware/rate_limit/redis_service.rs
@@ -101,7 +101,6 @@ where
         self.inner.poll_ready(cx)
     }
 
-    #[tracing::instrument(name = "rate_limit", skip_all)]
     fn call(&mut self, req: Request) -> Self::Future {
         // see: https://docs.rs/tower/latest/tower/trait.Service.html#be-careful-when-cloning-inner-services
         let mut this = self.clone();

--- a/ai-gateway/tests/cache.rs
+++ b/ai-gateway/tests/cache.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, time::Duration};
 
 use ai_gateway::{
-    config::{Config, helicone::HeliconeFeatures},
+    config::{Config, cache::CacheConfig, helicone::HeliconeFeatures},
     tests::{TestDefault, harness::Harness, mock::MockArgs},
 };
 use http::{Method, Request, StatusCode};
@@ -53,7 +53,8 @@ fn make_request(
 #[tokio::test]
 #[serial_test::serial(default_mock)]
 async fn cache_enabled_globally() {
-    let config = Config::test_default();
+    let mut config = Config::test_default();
+    config.global.cache = Some(CacheConfig::test_default());
 
     let mock_args = MockArgs::builder()
         .stubs(HashMap::from([

--- a/ai-gateway/tests/load_balance.rs
+++ b/ai-gateway/tests/load_balance.rs
@@ -5,7 +5,7 @@ use ai_gateway::{
         Config,
         balance::{BalanceConfig, BalanceConfigInner},
         helicone::HeliconeFeatures,
-        router::{RouterConfig, RouterConfigs, RouterRateLimitConfig},
+        router::{RouterConfig, RouterConfigs},
     },
     endpoints::EndpointType,
     tests::{TestDefault, harness::Harness, mock::MockArgs},
@@ -34,7 +34,7 @@ fn p2c_config_openai_anthropic_google() -> RouterConfigs {
             model_mappings: None,
             cache: None,
             retries: None,
-            rate_limit: RouterRateLimitConfig::default(),
+            rate_limit: None,
         },
     )]))
 }

--- a/ai-gateway/tests/rate_limit.rs
+++ b/ai-gateway/tests/rate_limit.rs
@@ -4,7 +4,7 @@ use ai_gateway::{
     config::{
         Config,
         helicone::HeliconeFeatures,
-        rate_limit::{GlobalRateLimitConfig, RateLimitStore},
+        rate_limit::{RateLimitConfig, RateLimitStore},
     },
     control_plane::types::{Key, hash_key},
     tests::{TestDefault, harness::Harness, mock::MockArgs},
@@ -59,7 +59,7 @@ async fn rate_limit_per_user_isolation_redis() {
 
 async fn rate_limit_capacity_enforced_impl(
     rate_limit_store: RateLimitStore,
-    rate_limit_config: GlobalRateLimitConfig,
+    rate_limit_config: RateLimitConfig,
 ) {
     let mut config = Config::test_default();
     config.helicone.features = HeliconeFeatures::All;
@@ -133,7 +133,7 @@ async fn rate_limit_capacity_enforced_impl(
 
 async fn rate_limit_per_user_isolation_impl(
     rate_limit_store: RateLimitStore,
-    rate_limit_config: GlobalRateLimitConfig,
+    rate_limit_config: RateLimitConfig,
 ) {
     let mut config = Config::test_default();
     config.helicone.features = HeliconeFeatures::All;

--- a/ai-gateway/tests/redis_cache.rs
+++ b/ai-gateway/tests/redis_cache.rs
@@ -1,7 +1,11 @@
 use std::{collections::HashMap, time::Duration};
 
 use ai_gateway::{
-    config::{Config, cache::CacheStore, helicone::HeliconeFeatures},
+    config::{
+        Config,
+        cache::{CacheConfig, CacheStore},
+        helicone::HeliconeFeatures,
+    },
     tests::{TestDefault, harness::Harness, mock::MockArgs},
 };
 use http::{Method, Request, StatusCode};
@@ -54,6 +58,7 @@ fn make_request(
 #[serial_test::serial(default_mock)]
 async fn cache_enabled_globally() {
     let mut config = Config::test_default();
+    config.global.cache = Some(CacheConfig::test_default());
 
     config.cache_store = CacheStore::Redis {
         host_url: "redis://localhost:6340".parse().unwrap(),


### PR DESCRIPTION
- Also, slightly refactor the rate limit config to be more consistent with other configs
- Update defaults in tests to disable global middleware, for scenarios where we want the middleware enabled in tests, we should enable it explicitly