### PR TITLE
task: log invalid key ids

### DIFF
--- a/ai-gateway/src/discover/router/cloud.rs
+++ b/ai-gateway/src/discover/router/cloud.rs
@@ -74,13 +74,7 @@ impl CloudDiscovery {
             .set_router_organization_map(router_organisation_map)
             .await;
 
-        let provider_keys = match router_store.get_all_provider_keys().await {
-            Ok(keys) => keys,
-            Err(e) => {
-                tracing::error!(error = %e, "Failed to get provider keys from router store");
-                FxHashMap::default()
-            }
-        };
+        let provider_keys = router_store.get_all_provider_keys_by_ids().await?;
         app_state
             .0
             .provider_keys


### PR DESCRIPTION
due to an issue with pgsodium throwing exceptions on empty strings, we currently have some invalid keys that prevent us from querying all keys. in order to fix this we are going to log the ids of the invalid keys and then delete them in the database, paired with adding new backend changes to use `null` instead of the empty string `''` when someone deletes their provider key or tries to manually set it to the empty string