### PR TITLE
fix: cache errors for refetched stale cached values

### DIFF
--- a/ai-gateway/config/local.yaml
+++ b/ai-gateway/config/local.yaml
@@ -7,6 +7,13 @@ helicone:
   websocket-url: "ws://localhost:8585/ws/v1/router/control-plane"
   features: none
 
+global:
+  cache:
+    directive: "max-age=10"
+
+cache-store:
+  type: in-memory
+
 routers:
   my-router:
     load-balance:

--- a/ai-gateway/src/middleware/cache/optional.rs
+++ b/ai-gateway/src/middleware/cache/optional.rs
@@ -27,16 +27,14 @@ impl Layer {
         Ok(Self { inner: layer })
     }
 
-    #[must_use]
-    pub fn global(app_state: &AppState) -> Self {
-        let layer = CacheLayer::global(app_state);
-        Self { inner: layer }
+    pub fn global(app_state: &AppState) -> Result<Self, InitError> {
+        let layer = CacheLayer::global(app_state)?;
+        Ok(Self { inner: layer })
     }
 
-    #[must_use]
-    pub fn unified_api(app_state: &AppState) -> Self {
-        let layer = CacheLayer::unified_api(app_state);
-        Self { inner: layer }
+    pub fn unified_api(app_state: &AppState) -> Result<Self, InitError> {
+        let layer = CacheLayer::unified_api(app_state)?;
+        Ok(Self { inner: layer })
     }
 
     /// For when we statically know that caching is disabled.

--- a/ai-gateway/src/router/router_details.rs
+++ b/ai-gateway/src/router/router_details.rs
@@ -259,12 +259,6 @@ where
             let response = future.await?;
             Ok(response)
         })
-
-        // match route {
-        //     RouteType::Router { id, path } => {
-        //         self.inner.call(req)
-        //     }
-        // }
     }
 }
 


### PR DESCRIPTION
this commit fixes an error that could occur due to the stale request parts not including any request extensions, causing a 404 when requests would get to the meta router.