### PR TITLE
refactor: stronger types in control plane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "ai-gateway"
-version = "0.2.0-beta.29"
+version = "0.2.0-beta.30"
 dependencies = [
  "anthropic-ai-sdk",
  "async-openai",
@@ -1761,7 +1761,7 @@ checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "dynamic-router"
-version = "0.2.0-beta.29"
+version = "0.2.0-beta.30"
 dependencies = [
  "futures",
  "http 1.3.1",
@@ -3023,7 +3023,7 @@ dependencies = [
 
 [[package]]
 name = "latency-router"
-version = "0.2.0-beta.29"
+version = "0.2.0-beta.30"
 dependencies = [
  "futures",
  "http 1.3.1",
@@ -3245,7 +3245,7 @@ dependencies = [
 
 [[package]]
 name = "mock-server"
-version = "0.2.0-beta.29"
+version = "0.2.0-beta.30"
 dependencies = [
  "ai-gateway",
  "axum",
@@ -3258,6 +3258,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -5606,7 +5607,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "telemetry"
-version = "0.2.0-beta.29"
+version = "0.2.0-beta.30"
 dependencies = [
  "http 1.3.1",
  "log-panics",
@@ -6208,6 +6209,7 @@ checksum = "6ef1b7a6d914a34127ed8e1fa927eb7088903787bcded4fa3eef8f85ee1568be"
 dependencies = [
  "thiserror 2.0.12",
  "ts-rs-macros",
+ "uuid",
 ]
 
 [[package]]
@@ -6591,7 +6593,7 @@ dependencies = [
 
 [[package]]
 name = "weighted-balance"
-version = "0.2.0-beta.29"
+version = "0.2.0-beta.30"
 dependencies = [
  "futures",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 authors = [ "Thomas Harmon <tom@helicone.ai>, Justin Torre <justin@helicone.ai>, Kavin Desi Valli <kavin@helicone.ai>, Charlie Wu <charlie@helicone.ai>", "Helicone Developers" ]
 license = "Apache-2.0"
 publish = false
-version = "0.2.0-beta.29"
+version = "0.2.0-beta.30"
 
 
 [profile.release]

--- a/ai-gateway/Cargo.toml
+++ b/ai-gateway/Cargo.toml
@@ -97,7 +97,7 @@ utoipa = { workspace = true }
 uuid = { workspace = true, features = ["serde", "v7"] }
 weighted-balance = { workspace = true }
 workspace_root = { workspace = true, optional = true }
-ts-rs = { workspace = true }
+ts-rs = { workspace = true, features = ["uuid-impl"] }
 
 [dev-dependencies]
 cargo-husky = { workspace = true, features = ["user-hooks"] }

--- a/ai-gateway/src/app.rs
+++ b/ai-gateway/src/app.rs
@@ -33,7 +33,7 @@ use crate::{
     cache::{CacheClient, RedisCacheManager},
     cli,
     config::{Config, DeploymentTarget, cache::CacheStore, server::TlsConfig},
-    control_plane::control_plane_state::ControlPlaneState,
+    control_plane::control_plane_state::StateWithMetadata,
     discover::monitor::{
         health::provider::HealthMonitorMap, metrics::EndpointMetricsRegistry,
         rate_limit::RateLimitMonitorMap,
@@ -247,7 +247,7 @@ impl App {
             pg_pool,
             jawn_http_client,
             control_plane_state: Arc::new(RwLock::new(
-                ControlPlaneState::default(),
+                StateWithMetadata::default(),
             )),
             provider_keys,
             global_rate_limit,

--- a/ai-gateway/src/app_state.rs
+++ b/ai-gateway/src/app_state.rs
@@ -14,7 +14,7 @@ use crate::{
         Config, rate_limit::RateLimiterConfig,
         response_headers::ResponseHeadersConfig,
     },
-    control_plane::{control_plane_state::ControlPlaneState, types::Key},
+    control_plane::{control_plane_state::StateWithMetadata, types::Key},
     discover::monitor::{
         health::provider::HealthMonitorMap, metrics::EndpointMetricsRegistry,
         rate_limit::RateLimitMonitorMap,
@@ -71,7 +71,7 @@ pub struct InnerAppState {
     pub rate_limit_receivers: RateLimitEventReceivers,
     pub router_tx: RwLock<Option<Sender<Change<RouterId, Router>>>>,
 
-    pub control_plane_state: Arc<RwLock<ControlPlaneState>>,
+    pub control_plane_state: Arc<RwLock<StateWithMetadata>>,
 
     pub provider_keys: ProviderKeys,
     pub helicone_api_keys: RwLock<Option<HashSet<Key>>>,

--- a/ai-gateway/src/control_plane/websocket.rs
+++ b/ai-gateway/src/control_plane/websocket.rs
@@ -17,7 +17,7 @@ use tokio_tungstenite::{
 use tracing::{debug, error};
 
 use super::{
-    control_plane_state::ControlPlaneState,
+    control_plane_state::StateWithMetadata,
     types::{MessageTypeRX, MessageTypeTX},
 };
 use crate::{
@@ -34,7 +34,7 @@ pub struct WebsocketChannel {
 
 #[derive(Debug)]
 pub struct ControlPlaneClient {
-    pub state: Arc<RwLock<ControlPlaneState>>,
+    pub state: Arc<RwLock<StateWithMetadata>>,
     channel: WebsocketChannel,
     /// Config about Control plane, such as the websocket url,
     /// reconnect interval/backoff policy, heartbeat interval, etc.
@@ -42,7 +42,7 @@ pub struct ControlPlaneClient {
 }
 
 async fn handle_message(
-    state: &Arc<RwLock<ControlPlaneState>>,
+    state: &Arc<RwLock<StateWithMetadata>>,
     message: Message,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let bytes = message.into_data();
@@ -128,7 +128,7 @@ impl ControlPlaneClient {
     }
 
     pub async fn connect(
-        control_plane_state: Arc<RwLock<ControlPlaneState>>,
+        control_plane_state: Arc<RwLock<StateWithMetadata>>,
         config: HeliconeConfig,
     ) -> Result<Self, InitError> {
         let channel = connect_with_retry(&config).await?;
@@ -230,7 +230,7 @@ mod tests {
     use crate::{
         config::helicone::HeliconeConfig,
         control_plane::{
-            control_plane_state::ControlPlaneState, types::MessageTypeTX,
+            control_plane_state::StateWithMetadata, types::MessageTypeTX,
         },
     };
 
@@ -277,7 +277,7 @@ mod tests {
             ..Default::default()
         };
 
-        let control_plane_state: Arc<RwLock<ControlPlaneState>> =
+        let control_plane_state: Arc<RwLock<StateWithMetadata>> =
             Arc::default();
         // This will fail if no server is running on 8585, which is expected
         let connect_fut = ControlPlaneClient::connect(

--- a/ai-gateway/src/error/auth.rs
+++ b/ai-gateway/src/error/auth.rs
@@ -6,7 +6,10 @@ use thiserror::Error;
 use super::api::ErrorResponse;
 use crate::{
     error::api::ErrorDetails,
-    middleware::mapper::openai::INVALID_REQUEST_ERROR_TYPE, types::json::Json,
+    middleware::mapper::openai::{
+        INVALID_REQUEST_ERROR_TYPE, SERVER_ERROR_TYPE,
+    },
+    types::json::Json,
 };
 
 #[derive(Debug, strum::AsRefStr, Error, Display)]
@@ -19,6 +22,8 @@ pub enum AuthError {
     ProviderKeyNotFound,
     /// Router not found
     RouterNotFound,
+    /// Auth data not ready
+    AuthDataNotReady,
 }
 
 impl IntoResponse for AuthError {
@@ -72,6 +77,18 @@ impl IntoResponse for AuthError {
                 }),
             )
                 .into_response(),
+            Self::AuthDataNotReady => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: ErrorDetails {
+                        message: Self::AuthDataNotReady.to_string(),
+                        r#type: Some(SERVER_ERROR_TYPE.to_string()),
+                        param: None,
+                        code: Some("auth_data_not_ready".to_string()),
+                    },
+                }),
+            )
+                .into_response(),
         }
     }
 }
@@ -89,6 +106,8 @@ pub enum AuthErrorMetric {
     ProviderKeyNotFound,
     /// Router not found
     RouterNotFound,
+    /// Auth data not ready
+    AuthDataNotReady,
 }
 
 impl From<&AuthError> for AuthErrorMetric {
@@ -100,6 +119,7 @@ impl From<&AuthError> for AuthErrorMetric {
             AuthError::InvalidCredentials => Self::InvalidCredentials,
             AuthError::ProviderKeyNotFound => Self::ProviderKeyNotFound,
             AuthError::RouterNotFound => Self::RouterNotFound,
+            AuthError::AuthDataNotReady => Self::AuthDataNotReady,
         }
     }
 }

--- a/ai-gateway/src/middleware/prompts/service.rs
+++ b/ai-gateway/src/middleware/prompts/service.rs
@@ -117,10 +117,11 @@ async fn build_prompt_request(
         ApiError::InvalidRequest(InvalidRequestError::InvalidRequestBody(e))
     })?;
 
-    tracing::debug!(
-        "Request JSON: {}",
-        serde_json::to_string_pretty(&request_json).unwrap_or_default()
-    );
+    if request_json.pointer("/prompt_id").is_none() {
+        let req =
+            Request::from_parts(parts, axum_core::body::Body::from(body_bytes));
+        return Ok(req);
+    }
 
     let Ok(prompt_ctx) = get_prompt_params(&request_json) else {
         let req =

--- a/ai-gateway/src/store/router.rs
+++ b/ai-gateway/src/store/router.rs
@@ -12,6 +12,7 @@ use crate::{
         org::OrgId,
         provider::{InferenceProvider, ProviderKey, ProviderKeyMap},
         secret::Secret,
+        user::UserId,
     },
 };
 
@@ -85,7 +86,7 @@ impl RouterStore {
             .into_iter()
             .map(|k| Key {
                 key_hash: k.key_hash,
-                owner_id: k.owner_id.to_string(),
+                owner_id: UserId::new(k.owner_id),
                 organization_id: OrgId::new(k.organization_id),
             })
             .collect();
@@ -119,7 +120,7 @@ impl RouterStore {
             .into_iter()
             .map(|k| Key {
                 key_hash: k.key_hash,
-                owner_id: k.owner_id.to_string(),
+                owner_id: UserId::new(k.owner_id),
                 organization_id: OrgId::new(k.organization_id),
             })
             .collect();

--- a/ai-gateway/src/types/org.rs
+++ b/ai-gateway/src/types/org.rs
@@ -1,10 +1,12 @@
-use derive_more::AsRef;
+use derive_more::{AsRef, From};
 use serde::{Deserialize, Serialize};
+use ts_rs::TS;
 use uuid::Uuid;
 
 use crate::error::auth::AuthError;
 
 #[derive(
+    TS,
     Debug,
     AsRef,
     Copy,
@@ -15,6 +17,7 @@ use crate::error::auth::AuthError;
     Serialize,
     Deserialize,
     Default,
+    From,
 )]
 pub struct OrgId(Uuid);
 

--- a/ai-gateway/src/types/user.rs
+++ b/ai-gateway/src/types/user.rs
@@ -1,12 +1,24 @@
-use derive_more::AsRef;
+use derive_more::{AsRef, From};
 use serde::{Deserialize, Serialize};
+use ts_rs::TS;
 use uuid::Uuid;
 
 use crate::error::auth::AuthError;
 
 #[derive(
-    Debug, AsRef, Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize,
+    TS,
+    Debug,
+    AsRef,
+    Copy,
+    Clone,
+    Eq,
+    PartialEq,
+    Hash,
+    Serialize,
+    Deserialize,
+    From,
 )]
+#[ts(export)]
 pub struct UserId(Uuid);
 
 impl UserId {

--- a/ai-gateway/tests/logger.rs
+++ b/ai-gateway/tests/logger.rs
@@ -131,6 +131,7 @@ async fn unauthenticated_sidecar() {
     let mut harness = Harness::builder()
         .with_config(config)
         .with_mock_args(mock_args)
+        .with_mock_auth()
         .build()
         .await;
     let body_bytes = serde_json::to_vec(&json!({
@@ -147,7 +148,6 @@ async fn unauthenticated_sidecar() {
     let request_body = axum_core::body::Body::from(body_bytes.clone());
     let request = Request::builder()
         .method(Method::POST)
-        .header("authorization", "Bearer sk-helicone-test-key")
         .uri("http://router.helicone.com/router/my-router/chat/completions")
         .body(request_body)
         .unwrap();

--- a/ai-gateway/tests/rate_limit.rs
+++ b/ai-gateway/tests/rate_limit.rs
@@ -163,12 +163,12 @@ async fn rate_limit_per_user_isolation_impl(
         .with_auth_keys(vec![
             Key {
                 key_hash: hash_key(user1_auth),
-                owner_id: user1_id.to_string(),
+                owner_id: user1_id.into(),
                 organization_id: OrgId::new(org1_id),
             },
             Key {
                 key_hash: hash_key(user2_auth),
-                owner_id: user2_id.to_string(),
+                owner_id: user2_id.into(),
                 organization_id: OrgId::new(org2_id),
             },
         ])

--- a/crates/mock-server/Cargo.toml
+++ b/crates/mock-server/Cargo.toml
@@ -19,6 +19,7 @@ serde_yml = "0.0.12"
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+uuid = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/mock-server/src/routes/jawn.rs
+++ b/crates/mock-server/src/routes/jawn.rs
@@ -1,9 +1,6 @@
 use std::time::Duration;
 
-use ai_gateway::{
-    control_plane::types::{MessageTypeRX, Update},
-    types::org::OrgId,
-};
+use ai_gateway::control_plane::types::{MessageTypeRX, Update};
 use axum::{
     Json,
     extract::{
@@ -14,6 +11,7 @@ use axum::{
     response::IntoResponse,
 };
 use futures::{SinkExt, StreamExt};
+use uuid::Uuid;
 
 use crate::AppState;
 
@@ -88,22 +86,22 @@ async fn websocket(stream: WebSocket) {
     }
 }
 
-fn mock_auth() -> ai_gateway::control_plane::types::Config {
+fn mock_auth() -> ai_gateway::control_plane::types::ControlPlaneState {
     let test_key = "sk-helicone-test-key";
     let key_hash = ai_gateway::control_plane::types::hash_key(test_key);
-    let organization_id = "c3bc2b69-c55c-4dfc-8a29-47db1245ee7c".to_string();
-    let user_id = "a41cbcd7-5e9e-4104-b29b-2ef4473d71a7".to_string();
-    ai_gateway::control_plane::types::Config {
+    let organization_id =
+        Uuid::parse_str("c3bc2b69-c55c-4dfc-8a29-47db1245ee7c").unwrap();
+    let user_id =
+        Uuid::parse_str("a41cbcd7-5e9e-4104-b29b-2ef4473d71a7").unwrap();
+    ai_gateway::control_plane::types::ControlPlaneState {
         auth: ai_gateway::control_plane::types::AuthData {
-            user_id: user_id.clone(),
-            organization_id: organization_id.clone(),
+            user_id: user_id.clone().into(),
+            organization_id: organization_id.clone().into(),
         },
         keys: vec![ai_gateway::control_plane::types::Key {
             key_hash: key_hash,
-            owner_id: user_id,
-            organization_id: OrgId::try_from(organization_id.as_str()).unwrap(),
+            owner_id: user_id.into(),
+            organization_id: organization_id.into(),
         }],
-        router_id: "my-router".to_string(),
-        router_config: "{}".to_string(),
     }
 }


### PR DESCRIPTION
- Replace string-based user_id and organization_id with typed UserId and OrgId
- Rename ControlPlaneState to StateWithMetadata and extract state to optional field
- Remove unused Ack message type and RequestConfig/SendLog variants
- Update auth middleware to handle new typed IDs
- Simplify router details service Future type to avoid unnecessary boxing
- Add uuid-impl feature to ts-rs for proper TypeScript generation
- since the removed variants aren't used and the other changes retain the same serialization format, these changes are not breaking