### PR TITLE
fix: better retry behavior, dont run cp in cloud

### DIFF
--- a/ai-gateway/src/config/control_plane.rs
+++ b/ai-gateway/src/config/control_plane.rs
@@ -1,0 +1,25 @@
+use std::time::Duration;
+
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+
+use crate::config::retry::RetryConfig;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
+pub struct ControlPlaneConfig {
+    pub retry: RetryConfig,
+}
+
+impl Default for ControlPlaneConfig {
+    fn default() -> Self {
+        Self {
+            retry: RetryConfig::Exponential {
+                min_delay: Duration::from_secs(2),
+                max_delay: Duration::from_secs(60),
+                max_retries: 15,
+                factor: Decimal::from(2),
+            },
+        }
+    }
+}

--- a/ai-gateway/src/config/mod.rs
+++ b/ai-gateway/src/config/mod.rs
@@ -1,5 +1,6 @@
 pub mod balance;
 pub mod cache;
+pub mod control_plane;
 pub mod database;
 pub mod discover;
 pub mod dispatcher;
@@ -80,6 +81,7 @@ pub struct Config {
     pub discover: self::discover::DiscoverConfig,
     pub response_headers: self::response_headers::ResponseHeadersConfig,
     pub deployment_target: DeploymentTarget,
+    pub control_plane: self::control_plane::ControlPlaneConfig,
 
     /// If a request is made with a model that is not in the `RouterConfig`
     /// model mapping, then we fallback to this.
@@ -212,6 +214,7 @@ impl crate::tests::TestDefault for Config {
             minio: self::minio::Config::test_default(),
             database: self::database::DatabaseConfig::test_default(),
             dispatcher: self::dispatcher::DispatcherConfig::test_default(),
+            control_plane: self::control_plane::ControlPlaneConfig::default(),
             default_model_mapping:
                 self::model_mapping::ModelMappingConfig::default(),
             global: MiddlewareConfig::default(),


### PR DESCRIPTION
this commit disabled the control plane in cloud mode as it's not needed, as well as improving the retry behavior so that we avoid retry storms if there are lots of sidecar instances and Jawn goes down