### PR TITLE
feat: add helicone cloud config

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -7,7 +7,10 @@ on:
     branches: ["main"]
     paths:
       - "crates/**"
-      - "ai-gateway/**"
+      - "ai-gateway/src/**"
+      - "ai-gateway/stubs/**"
+      - "ai-gateway/tests/**"
+      - "ai-gateway/Cargo.toml"
 
 env:
   CARGO_TERM_COLOR: always

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,8 @@ FROM debian:bookworm-slim AS runtime
 RUN apt-get update && apt install -y openssl ca-certificates && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=builder /app/target/release/ai-gateway /usr/local/bin
+
+# for ease of deployment in AWS
+COPY ai-gateway/config/helicone-cloud.yaml /etc/ai-gateway/helicone-cloud.yaml
+
 CMD ["/usr/local/bin/ai-gateway"]

--- a/ai-gateway/config/helicone-cloud.yaml
+++ b/ai-gateway/config/helicone-cloud.yaml
@@ -1,0 +1,18 @@
+telemetry:
+  level: "info,ai_gateway=debug"
+  format: "compact"
+  exporter: both
+
+helicone:
+  features: all
+
+minio:
+  bucket-name: "request-response-storage"
+
+cache-store:
+  type: redis
+
+rate-limit-store:
+  type: redis
+
+deployment-target: cloud

--- a/infrastructure/terraform/ecs/terraform.tfvars.example
+++ b/infrastructure/terraform/ecs/terraform.tfvars.example
@@ -1,0 +1,3 @@
+environment = "dev"
+region      = "us-east-1"
+image_tag   = "latest"

--- a/infrastructure/terraform/ecs/tfplan
+++ b/infrastructure/terraform/ecs/tfplan
@@ -1,1 +1,0 @@
-{"remote_plan_format":1,"run_id":"run-gcxSJwcpZ2yj5C8z","hostname":"app.terraform.io"}


### PR DESCRIPTION
for ease of deployment in AWS, this commit adds non-sensitive cloud configurations for helicone. the alternative requires initcontainers or and volume mounts and this is much simpler.

in addition, this commit updates the CI trigger rules so that we do not have to wait for rust ci to run if we only want to update the config