### PR TITLE
fix: remove autoscaling policy

### DIFF
--- a/ai-gateway/src/store/router.rs
+++ b/ai-gateway/src/store/router.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use chrono::{DateTime, Utc};
 use rustc_hash::FxHashMap;
 use sqlx::PgPool;
-use tracing::{error, warn};
+use tracing::{error, trace, warn};
 use uuid::Uuid;
 
 use crate::{
@@ -186,7 +186,7 @@ impl RouterStore {
                 ) {
                     Ok(provider) => provider,
                     Err(e) => {
-                        warn!(error = %e, provider_name = %key.provider_name, "Failed to parse inference provider, skipping");
+                        trace!(error = %e, provider_name = %key.provider_name, "Failed to parse inference provider, skipping");
                         continue;
                     }
                 };

--- a/infrastructure/terraform/ecs/outputs.tf
+++ b/infrastructure/terraform/ecs/outputs.tf
@@ -98,27 +98,7 @@ output "subnet_ids" {
   value       = data.aws_subnets.default.ids
 }
 
-output "autoscaling_target_resource_id" {
-  description = "Resource ID of the autoscaling target"
-  value       = aws_appautoscaling_target.ecs_target.resource_id
-}
-
-output "autoscaling_policy_name" {
-  description = "Name of the autoscaling policy"
-  value       = aws_appautoscaling_policy.ecs_cpu_policy.name
-}
-
-output "autoscaling_min_capacity" {
-  description = "Minimum number of tasks for autoscaling"
-  value       = aws_appautoscaling_target.ecs_target.min_capacity
-}
-
-output "autoscaling_max_capacity" {
-  description = "Maximum number of tasks for autoscaling"
-  value       = aws_appautoscaling_target.ecs_target.max_capacity
-}
-
-output "autoscaling_target_cpu_utilization" {
-  description = "Target CPU utilization percentage for autoscaling"
-  value       = aws_appautoscaling_policy.ecs_cpu_policy.target_tracking_scaling_policy_configuration[0].target_value
+output "ecs_desired_count" {
+  description = "Desired number of ECS tasks"
+  value       = aws_ecs_service.ai-gateway_service.desired_count
 } 


### PR DESCRIPTION
wasnt working due to the heavy load on startup, which caused us to instantly scale to the max count when redeploying which is not desired