### PR TITLE
fix: dont load initial keys from db listener

### DIFF
--- a/ai-gateway/src/app.rs
+++ b/ai-gateway/src/app.rs
@@ -233,6 +233,14 @@ impl App {
                 .get_all_helicone_api_keys()
                 .await
                 .map_err(|e| InitError::InitHeliconeKeys(e.to_string()))?;
+            tracing::info!(
+                "loaded initial {} helicone api keys",
+                helicone_api_keys.len()
+            );
+            metrics.routers.helicone_api_keys.add(
+                i64::try_from(helicone_api_keys.len()).unwrap_or(i64::MAX),
+                &[],
+            );
 
             Some(helicone_api_keys)
         } else {

--- a/ai-gateway/src/store/db_listener.rs
+++ b/ai-gateway/src/store/db_listener.rs
@@ -161,19 +161,7 @@ impl DatabaseListener {
                     error!(error = %e, "failed to poll api keys");
                 })?
         } else {
-            // First poll - get all active API keys
-            self.router_store
-                .get_all_db_helicone_api_keys()
-                .await
-                .inspect(|keys| {
-                    info!(
-                        "polling initialized with {} helicone api keys",
-                        keys.len()
-                    );
-                })
-                .inspect_err(|e| {
-                    error!(error = %e, "failed to poll api keys");
-                })?
+            Vec::new()
         };
 
         // Process API key changes


### PR DESCRIPTION
initial helicone api keys are instead fetched in `build_app_state`