### PR TITLE
feat(providers): add EmpirioLabs to provider registry

### DIFF
--- a/ai-gateway/config/embedded/providers.yaml
+++ b/ai-gateway/config/embedded/providers.yaml
@@ -94,6 +94,17 @@ xai:
     - "grok-2-vision"
   base-url: https://api.x.ai/
 
+empiriolabs:
+  models:
+    - "qwen3-7-plus"
+    - "qwen3-7-max"
+    - "deepseek-v4-pro"
+    - "deepseek-v4-flash"
+    - "glm-5-1"
+    - "kimi-k2-7-code"
+    - "minimax-m3"
+  base-url: https://api.empiriolabs.ai/
+
 hyperbolic:
   models:
     - "moonshotai/Kimi-K2-Instruct"


### PR DESCRIPTION
## What

Adds **EmpirioLabs** to the embedded provider registry (`ai-gateway/config/embedded/providers.yaml`).

EmpirioLabs is an OpenAI-compatible multi-model API provider (`https://api.empiriolabs.ai`). This entry mirrors the existing OpenAI-compatible provider entries (`deepseek`, `xai`, `groq`, `mistral`) exactly: a `models` list plus a trailing-slash `base-url`, with no `version` field. Because it is not one of the built-in providers, it deserializes into `InferenceProvider::Named(...)`, which the gateway already routes as OpenAI-compatible (`v1/chat/completions` appended to the base URL), resolving to `https://api.empiriolabs.ai/v1/chat/completions`.

```yaml
empiriolabs:
  models:
    - "qwen3-7-plus"
    - "qwen3-7-max"
    - "deepseek-v4-pro"
    - "deepseek-v4-flash"
    - "glm-5-1"
    - "kimi-k2-7-code"
    - "minimax-m3"
  base-url: https://api.empiriolabs.ai/
```

## Why

So users running the gateway can route to EmpirioLabs models out of the box, the same way the other OpenAI-compatible providers in the registry work. The provider API key is discovered from the `EMPIRIOLABS_API_KEY` environment variable, consistent with the existing `<PROVIDER>_API_KEY` convention.

## Notes

- Single-file change, no new config keys beyond what sibling entries already use (`models`, `base-url`).
- YAML validated; structure verified to match the `xai` / `deepseek` blocks.
