### PR TITLE
fix(webhook): authenticate ingest POSTs with a shared secret

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,13 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Festoon Fork Context (read first)
+
+- This repo is **Festoon's fork** of Helicone's ai-gateway. Festoon's delta is the **capture webhook**: the dispatcher tees each request/response and `logger/service.rs` POSTs it to the Festoon API ingest endpoint (auth via shared secret; org/user via `X-Festoon-Org` / `X-Festoon-User` headers).
+- Role: **Channel 2 (API/dev-tool capture)** in Festoon's multi-channel architecture — no longer the primary capture layer. See `docs/decisions/2026-07-22-synthesis-pivot.md` in the main `festoon` repo.
+- **Maintenance posture: upstream security syncs only.** Do not add features here unless explicitly asked; keep the Festoon delta minimal to ease upstream merges (`upstream` remote → Helicone/ai-gateway).
+- **License: GPL v3** (upstream relicensed from Apache 2.0 in Nov 2025). Do not describe this repo as Apache-licensed. Distributing modified binaries triggers GPL source obligations.
+
 ## Key Commands
 
 ### Development

--- a/README.md
+++ b/README.md
@@ -1,3 +1,31 @@
+# Festoon Gateway (fork of Helicone AI Gateway)
+
+> **Role in Festoon: one capture channel, not the spine.**
+>
+> This is Festoon's fork of [Helicone's ai-gateway](https://github.com/Helicone/ai-gateway)
+> (Rust). It proxies **API/dev-tool traffic** — anything with a configurable
+> base URL (Cursor, agent CLIs, SDKs, internal apps) — and POSTs each captured
+> request/response to the Festoon API ingest endpoint (the webhook addition in
+> `ai-gateway/src/logger/service.rs` + dispatcher wiring is the Festoon delta;
+> everything else is upstream).
+>
+> It is **Channel 2** in Festoon's multi-channel capture architecture
+> (Channel 1: MCP contribute loop + hooks; Channel 3: vendor compliance APIs).
+> It was formerly the primary capture layer; demoted per
+> [`docs/decisions/2026-07-22-synthesis-pivot.md`](https://github.com/standley-brent/festoon/blob/main/docs/decisions/2026-07-22-synthesis-pivot.md).
+>
+> **Maintenance posture:** upstream security syncs only; no feature work unless
+> customer traffic demands it.
+>
+> **License note:** upstream relicensed Apache 2.0 → **GPL v3** (Nov 2025);
+> this fork is **GPL v3** (see [LICENSE](LICENSE)). Running it as a hosted or
+> self-hosted service is fine; *distributing* modified binaries triggers GPL
+> source obligations; it cannot be combined into a proprietary distribution.
+
+---
+
+Upstream README follows.
+
 ![Helicone AI Gateway](https://marketing-assets-helicone.s3.us-west-2.amazonaws.com/github-w%3Alogo.png)
 
 # Helicone AI Gateway
@@ -5,7 +33,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/Helicone/ai-gateway?style=for-the-badge)](https://github.com/helicone/ai-gateway/)
 [![Downloads](https://img.shields.io/github/downloads/Helicone/ai-gateway/total?style=for-the-badge)](https://github.com/helicone/aia-gateway/releases)
 [![Docker pulls](https://img.shields.io/docker/pulls/helicone/ai-gateway?style=for-the-badge)](https://hub.docker.com/r/helicone/ai-gateway)
-[![License](https://img.shields.io/badge/license-APACHE-green?style=for-the-badge)](LICENSE)
+[![License](https://img.shields.io/badge/license-GPL--3.0-blue?style=for-the-badge)](LICENSE)
 [![Public Beta](https://img.shields.io/badge/status-Public%20Beta-orange?style=for-the-badge)](https://github.com/helicone/ai-gateway)
 
 **The fastest, lightest, and easiest-to-integrate AI Gateway on the market.**
@@ -330,7 +358,7 @@ For a complete guide on self-hosting options, including Docker deployment, Kuber
 
 ## 📄 License
 
-The Helicone AI Gateway is licensed under the [Apache License](LICENSE) - see the file for details.
+The Helicone AI Gateway (and therefore this fork) is licensed under the [GNU General Public License v3.0](LICENSE) — see the file for details. Upstream relicensed from Apache 2.0 to GPL v3 in November 2025; Festoon's modifications are likewise GPL v3.
 
 ---
 

--- a/ai-gateway/config/embedded/providers.yaml
+++ b/ai-gateway/config/embedded/providers.yaml
@@ -113,6 +113,21 @@ hyperbolic:
     - "NousResearch/Hermes-3-Llama-3.1-70B"
   base-url: https://api.hyperbolic.xyz/
 
+cohere:
+  models:
+    - "command-a-plus-05-2026"
+    - "command-a-03-2025"
+    - "command-a-reasoning-08-2025"
+    - "command-a-vision-07-2025"
+    - "command-a-translate-08-2025"
+    - "command-r7b-12-2024"
+    - "command-r-08-2024"
+    - "command-r-plus-08-2024"
+    - "command-r"
+    - "command-r-plus"
+  # Cohere's OpenAI-compatible endpoint; the gateway appends `v1/chat/completions`
+  base-url: https://api.cohere.ai/compatibility/
+
 ollama:
   models:
     - "deepseek-r1"

--- a/ai-gateway/config/embedded/providers.yaml
+++ b/ai-gateway/config/embedded/providers.yaml
@@ -128,6 +128,24 @@ cohere:
   # Cohere's OpenAI-compatible endpoint; the gateway appends `v1/chat/completions`
   base-url: https://api.cohere.ai/compatibility/
 
+huggingface:
+  # HF Inference Providers is itself a router over many backends (Together,
+  # Groq, SambaNova, Cerebras, ...). Append a policy suffix to a model id to
+  # steer routing, e.g. `:fastest` (default), `:cheapest`, or `:<provider>`.
+  models:
+    - "openai/gpt-oss-120b"
+    - "meta-llama/Llama-3.3-70B-Instruct"
+    - "meta-llama/Llama-3.1-8B-Instruct"
+    - "deepseek-ai/DeepSeek-V4-Pro"
+    - "deepseek-ai/DeepSeek-V4-Flash"
+    - "Qwen/Qwen3-Coder-Next"
+    - "zai-org/GLM-5.2"
+    - "google/gemma-4-31B-it"
+    - "moonshotai/Kimi-K2.7-Code"
+    - "MiniMaxAI/MiniMax-M3"
+  # HF's OpenAI-compatible router; the gateway appends `v1/chat/completions`
+  base-url: https://router.huggingface.co/
+
 ollama:
   models:
     - "deepseek-r1"

--- a/ai-gateway/config/festoon.yaml
+++ b/ai-gateway/config/festoon.yaml
@@ -1,0 +1,15 @@
+# Festoon Gateway — local development config
+#
+# Usage:
+#   cargo run -- -c ai-gateway/config/festoon.yaml
+#
+# Or set env var:
+#   AI_GATEWAY__WEBHOOK__URL=http://localhost:8000/api/gateway/ingest
+
+# Disable Helicone features — we don't need auth or observability.
+helicone:
+  features: none
+
+# POST captured request/response to Festoon API ingest endpoint.
+webhook:
+  url: "http://localhost:8000/api/gateway/ingest"

--- a/ai-gateway/src/config/mod.rs
+++ b/ai-gateway/src/config/mod.rs
@@ -17,6 +17,7 @@ pub mod retry;
 pub mod router;
 pub mod server;
 pub mod validation;
+pub mod webhook;
 use std::path::PathBuf;
 
 use config::ConfigError;
@@ -96,6 +97,8 @@ pub struct Config {
     /// requests to the unified API (`/ai`)
     pub unified_api: MiddlewareConfig,
     pub routers: self::router::RouterConfigs,
+    /// Festoon webhook: POST full request/response to an external endpoint.
+    pub webhook: self::webhook::WebhookConfig,
 }
 
 impl Config {
@@ -219,6 +222,7 @@ impl crate::tests::TestDefault for Config {
             routers: self::router::RouterConfigs::test_default(),
             response_headers:
                 self::response_headers::ResponseHeadersConfig::default(),
+            webhook: self::webhook::WebhookConfig::default(),
         }
     }
 }

--- a/ai-gateway/src/config/webhook.rs
+++ b/ai-gateway/src/config/webhook.rs
@@ -1,0 +1,22 @@
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+/// Configuration for the Festoon webhook.
+///
+/// When `url` is set, the gateway POSTs the full request/response bodies
+/// (as JSON) to this endpoint after every proxied AI request.
+#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct WebhookConfig {
+    /// The URL to POST captured interactions to (e.g. http://localhost:8000/api/gateway/ingest).
+    /// If None, webhooks are disabled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<Url>,
+}
+
+impl WebhookConfig {
+    #[must_use]
+    pub fn is_enabled(&self) -> bool {
+        self.url.is_some()
+    }
+}

--- a/ai-gateway/src/config/webhook.rs
+++ b/ai-gateway/src/config/webhook.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -5,20 +7,41 @@ use url::Url;
 ///
 /// When `url` is set, the gateway POSTs the full request/response bodies
 /// (as JSON) to this endpoint after every proxied AI request.
-#[derive(
-    Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq, Hash,
-)]
+///
+/// When `secret` is set, each POST carries it as an `x-ingest-secret`
+/// header. The Festoon API rejects unauthenticated ingest whenever its
+/// own `FESTOON_GATEWAY_INGEST_SECRET` is configured, so the two must
+/// match for capture to work.
+#[derive(Default, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct WebhookConfig {
     /// The URL to POST captured interactions to (e.g. http://localhost:8000/api/gateway/ingest).
     /// If None, webhooks are disabled.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<Url>,
+
+    /// Shared secret sent as the `x-ingest-secret` header. If None, the
+    /// POST is unauthenticated — only valid against an API that has no
+    /// ingest secret configured.
+    ///
+    /// Never serialized: config dumps must not leak it.
+    #[serde(skip_serializing)]
+    pub secret: Option<String>,
 }
 
 impl WebhookConfig {
     #[must_use]
     pub fn is_enabled(&self) -> bool {
         self.url.is_some()
+    }
+}
+
+/// Manual `Debug` so the secret is redacted in logs and traces.
+impl fmt::Debug for WebhookConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WebhookConfig")
+            .field("url", &self.url)
+            .field("secret", &self.secret.as_ref().map(|_| "<redacted>"))
+            .finish()
     }
 }

--- a/ai-gateway/src/config/webhook.rs
+++ b/ai-gateway/src/config/webhook.rs
@@ -5,7 +5,9 @@ use url::Url;
 ///
 /// When `url` is set, the gateway POSTs the full request/response bodies
 /// (as JSON) to this endpoint after every proxied AI request.
-#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq, Hash,
+)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct WebhookConfig {
     /// The URL to POST captured interactions to (e.g. http://localhost:8000/api/gateway/ingest).

--- a/ai-gateway/src/dispatcher/service.rs
+++ b/ai-gateway/src/dispatcher/service.rs
@@ -41,7 +41,7 @@ use crate::{
     types::{
         body::BodyReader,
         extensions::{
-            MapperContext, PromptContext, RequestContext, RequestKind,
+            AuthContext, MapperContext, PromptContext, RequestContext, RequestKind,
         },
         model_id::ModelId,
         provider::InferenceProvider,
@@ -556,6 +556,42 @@ impl Dispatcher {
                     .instrument(tracing::Span::current()),
                 );
             }
+        } else if self.app_state.config().webhook.is_enabled() {
+            // Helicone observability is off, but webhook is configured.
+            // Build a LoggerService to collect the body and fire the webhook.
+            let auth_ctx = req_ctx.auth_context.clone().unwrap_or_else(|| {
+                use crate::types::{org::OrgId, user::UserId};
+                AuthContext {
+                    user_id: UserId::new(Uuid::nil()),
+                    org_id: OrgId::new(Uuid::nil()),
+                    api_key: crate::types::secret::Secret::from(String::new()),
+                }
+            });
+            let response_logger = LoggerService::builder()
+                .app_state(self.app_state.clone())
+                .auth_ctx(auth_ctx)
+                .start_time(start_time)
+                .start_instant(start_instant)
+                .target_url(target_url)
+                .request_headers(headers)
+                .request_body(req_body_bytes)
+                .response_status(client_response.status())
+                .response_body(response_body_for_logger)
+                .provider(self.provider.clone())
+                .tfft_rx(tfft_rx)
+                .mapper_ctx(mapper_ctx.clone())
+                .router_id(router_id)
+                .deployment_target(deployment_target)
+                .request_id(helicone_request_id)
+                .prompt_ctx(prompt_ctx)
+                .build();
+
+            tokio::spawn(
+                async move {
+                    response_logger.log_webhook_only().await;
+                }
+                .instrument(tracing::Span::current()),
+            );
         } else {
             let app_state = self.app_state.clone();
             let model = mapper_ctx.model.as_ref().map_or_else(

--- a/ai-gateway/src/dispatcher/service.rs
+++ b/ai-gateway/src/dispatcher/service.rs
@@ -41,7 +41,8 @@ use crate::{
     types::{
         body::BodyReader,
         extensions::{
-            AuthContext, MapperContext, PromptContext, RequestContext, RequestKind,
+            AuthContext, MapperContext, PromptContext, RequestContext,
+            RequestKind,
         },
         model_id::ModelId,
         provider::InferenceProvider,

--- a/ai-gateway/src/logger/service.rs
+++ b/ai-gateway/src/logger/service.rs
@@ -7,6 +7,7 @@ use http_body_util::BodyExt;
 use indexmap::IndexMap;
 use opentelemetry::KeyValue;
 use reqwest::Client;
+use serde::Serialize;
 use tokio::{sync::oneshot, time::Instant};
 use typed_builder::TypedBuilder;
 use url::Url;
@@ -48,6 +49,20 @@ impl JawnClient {
     }
 }
 
+/// Payload POSTed to the Festoon webhook endpoint.
+#[derive(Debug, Serialize)]
+pub struct WebhookPayload {
+    pub provider: String,
+    pub model: String,
+    pub request_body: serde_json::Value,
+    pub response_body: serde_json::Value,
+    pub status_code: u16,
+    pub latency_ms: u64,
+    pub user_id: Option<String>,
+    pub org_slug: Option<String>,
+    pub properties: IndexMap<String, String>,
+}
+
 #[derive(Debug, TypedBuilder)]
 pub struct LoggerService {
     app_state: AppState,
@@ -82,6 +97,10 @@ impl LoggerService {
     #[allow(clippy::cast_precision_loss, clippy::too_many_lines)]
     pub async fn log(mut self) -> Result<(), LoggerError> {
         tracing::trace!("logging request");
+
+        // Clone request_body before response_body.collect() partially moves self.
+        let req_body_for_webhook = self.request_body.clone();
+
         let tfft_future = TFFTFuture::new(self.start_instant, self.tfft_rx);
         let collect_future = self.response_body.collect();
         let (response_body, tfft_duration) =
@@ -97,6 +116,24 @@ impl LoggerService {
         tracing::trace!(tfft_duration = ?tfft_duration, "tfft_duration");
         let req_body_len = self.request_body.len();
         let resp_body_len = response_body.len();
+
+        // --- Festoon webhook: POST full bodies to external endpoint ---
+        if let Some(webhook_url) = self.app_state.config().webhook.url.clone() {
+            send_webhook(
+                &self.app_state,
+                &self.auth_ctx,
+                &self.request_headers,
+                self.provider.clone(),
+                &self.mapper_ctx,
+                self.response_status,
+                webhook_url,
+                &req_body_for_webhook,
+                &response_body,
+                tfft_duration,
+            )
+            .await;
+        }
+
         let s3_client = if self.app_state.config().deployment_target.is_cloud()
         {
             MinioClient::cloud(&self.app_state.0.minio)
@@ -213,5 +250,165 @@ impl LoggerService {
 
         tracing::debug!("successfully logged request");
         Ok(())
+    }
+
+    /// POST the full request/response bodies to a webhook-only logger.
+    ///
+    /// This is used when Helicone observability is disabled but the webhook
+    /// is configured. Collects the response body and fires the webhook.
+    #[tracing::instrument(skip_all)]
+    pub async fn log_webhook_only(self) {
+        // Extract fields we need before collect() partially moves self.
+        let app_state = self.app_state;
+        let auth_ctx = self.auth_ctx;
+        let request_headers = self.request_headers;
+        let provider = self.provider;
+        let mapper_ctx = self.mapper_ctx;
+        let response_status = self.response_status;
+        let request_body = self.request_body;
+        let target_url = self.target_url;
+
+        let tfft_future = TFFTFuture::new(self.start_instant, self.tfft_rx);
+        let collect_future = self.response_body.collect();
+        let (response_body, tfft_duration) =
+            tokio::join!(collect_future, tfft_future);
+        let response_body = match response_body {
+            Ok(body) => body.to_bytes(),
+            Err(_) => {
+                tracing::error!("failed to collect response body for webhook");
+                return;
+            }
+        };
+        let tfft_duration = tfft_duration.unwrap_or_else(|_| {
+            Duration::from_secs(0)
+        });
+
+        // Record TFFT metric.
+        let model = mapper_ctx
+            .model
+            .as_ref()
+            .map_or_else(|| "unknown".to_string(), ToString::to_string);
+        let attributes = [
+            KeyValue::new("provider", provider.to_string()),
+            KeyValue::new("model", model),
+            KeyValue::new("path", target_url.path().to_string()),
+        ];
+        #[allow(clippy::cast_precision_loss)]
+        app_state
+            .0
+            .metrics
+            .tfft_duration
+            .record(tfft_duration.as_millis() as f64, &attributes);
+
+        if let Some(webhook_url) = app_state.config().webhook.url.clone() {
+            send_webhook(
+                &app_state,
+                &auth_ctx,
+                &request_headers,
+                provider.clone(),
+                &mapper_ctx,
+                response_status,
+                webhook_url,
+                &request_body,
+                &response_body,
+                tfft_duration,
+            )
+            .await;
+        }
+    }
+}
+
+/// Fire the webhook POST to the configured URL.
+async fn send_webhook(
+    app_state: &AppState,
+    auth_ctx: &AuthContext,
+    request_headers: &HeaderMap,
+    provider: InferenceProvider,
+    mapper_ctx: &MapperContext,
+    response_status: StatusCode,
+    webhook_url: Url,
+    request_body: &Bytes,
+    response_body: &Bytes,
+    latency: Duration,
+) {
+    let model = mapper_ctx
+        .model
+        .as_ref()
+        .map_or_else(|| "unknown".to_string(), ToString::to_string);
+
+    let provider_str = match provider {
+        InferenceProvider::Ollama => "custom".to_string(),
+        InferenceProvider::GoogleGemini => "google".to_string(),
+        provider => provider.to_string().to_lowercase(),
+    };
+
+    // Extract helicone-property-* headers as properties.
+    let mut properties = IndexMap::new();
+    for (name, value) in request_headers {
+        if name.as_str().starts_with("helicone-property-") {
+            if let Ok(value_str) = value.to_str() {
+                let key = name
+                    .as_str()
+                    .strip_prefix("helicone-property-")
+                    .unwrap_or(name.as_str())
+                    .to_string();
+                properties.insert(key, value_str.to_string());
+            }
+        }
+    }
+
+    // Extract user_id and org_slug from properties or auth context.
+    let user_id = properties
+        .swap_remove("X-Festoon-User")
+        .or_else(|| {
+            let uid = auth_ctx.user_id.to_string();
+            // Skip nil UUIDs (placeholder when auth is disabled).
+            if uid == "00000000-0000-0000-0000-000000000000" {
+                None
+            } else {
+                Some(uid)
+            }
+        });
+    let org_slug = properties.swap_remove("X-Festoon-Org");
+
+    let req_json: serde_json::Value =
+        serde_json::from_slice(request_body).unwrap_or_default();
+    let resp_json: serde_json::Value =
+        serde_json::from_slice(response_body).unwrap_or_default();
+
+    let payload = WebhookPayload {
+        provider: provider_str,
+        model,
+        request_body: req_json,
+        response_body: resp_json,
+        status_code: response_status.as_u16(),
+        #[allow(clippy::cast_possible_truncation)]
+        latency_ms: latency.as_millis() as u64,
+        user_id,
+        org_slug,
+        properties,
+    };
+
+    match app_state
+        .0
+        .jawn_http_client
+        .request_client
+        .post(webhook_url.as_str())
+        .json(&payload)
+        .send()
+        .await
+    {
+        Ok(resp) if resp.status().is_success() => {
+            tracing::debug!("webhook POST succeeded");
+        }
+        Ok(resp) => {
+            tracing::warn!(
+                status = %resp.status(),
+                "webhook POST returned non-success status"
+            );
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "webhook POST failed");
+        }
     }
 }

--- a/ai-gateway/src/logger/service.rs
+++ b/ai-gateway/src/logger/service.rs
@@ -98,7 +98,8 @@ impl LoggerService {
     pub async fn log(mut self) -> Result<(), LoggerError> {
         tracing::trace!("logging request");
 
-        // Clone request_body before response_body.collect() partially moves self.
+        // Clone request_body before response_body.collect() partially moves
+        // self.
         let req_body_for_webhook = self.request_body.clone();
 
         let tfft_future = TFFTFuture::new(self.start_instant, self.tfft_rx);
@@ -279,9 +280,8 @@ impl LoggerService {
                 return;
             }
         };
-        let tfft_duration = tfft_duration.unwrap_or_else(|_| {
-            Duration::from_secs(0)
-        });
+        let tfft_duration =
+            tfft_duration.unwrap_or_else(|_| Duration::from_secs(0));
 
         // Record TFFT metric.
         let model = mapper_ctx
@@ -358,17 +358,15 @@ async fn send_webhook(
     }
 
     // Extract user_id and org_slug from properties or auth context.
-    let user_id = properties
-        .swap_remove("X-Festoon-User")
-        .or_else(|| {
-            let uid = auth_ctx.user_id.to_string();
-            // Skip nil UUIDs (placeholder when auth is disabled).
-            if uid == "00000000-0000-0000-0000-000000000000" {
-                None
-            } else {
-                Some(uid)
-            }
-        });
+    let user_id = properties.swap_remove("X-Festoon-User").or_else(|| {
+        let uid = auth_ctx.user_id.to_string();
+        // Skip nil UUIDs (placeholder when auth is disabled).
+        if uid == "00000000-0000-0000-0000-000000000000" {
+            None
+        } else {
+            Some(uid)
+        }
+    });
     let org_slug = properties.swap_remove("X-Festoon-Org");
 
     let req_json: serde_json::Value =

--- a/ai-gateway/src/logger/service.rs
+++ b/ai-gateway/src/logger/service.rs
@@ -387,15 +387,19 @@ async fn send_webhook(
         properties,
     };
 
-    match app_state
+    let mut request = app_state
         .0
         .jawn_http_client
         .request_client
         .post(webhook_url.as_str())
-        .json(&payload)
-        .send()
-        .await
-    {
+        .json(&payload);
+
+    // Authenticate to the Festoon ingest endpoint when a secret is set.
+    if let Some(secret) = app_state.config().webhook.secret.as_ref() {
+        request = request.header("x-ingest-secret", secret);
+    }
+
+    match request.send().await {
         Ok(resp) if resp.status().is_success() => {
             tracing::debug!("webhook POST succeeded");
         }

--- a/ai-gateway/src/middleware/mapper/registry.rs
+++ b/ai-gateway/src/middleware/mapper/registry.rs
@@ -248,6 +248,23 @@ impl EndpointConverterRegistryInner {
         ));
         registry.register_converter(key, converter);
 
+        let key = RegistryKey::new(
+            ApiEndpoint::OpenAI(OpenAI::chat_completions()),
+            ApiEndpoint::OpenAICompatible {
+                provider: InferenceProvider::Named("huggingface".into()),
+                openai_endpoint: OpenAI::chat_completions(),
+            },
+        );
+        let converter = TypedEndpointConverter::<
+            endpoints::openai::ChatCompletions,
+            endpoints::openai::OpenAICompatibleChatCompletions,
+            OpenAICompatibleConverter,
+        >::new(OpenAICompatibleConverter::new(
+            InferenceProvider::Named("huggingface".into()),
+            model_mapper.clone(),
+        ));
+        registry.register_converter(key, converter);
+
         registry
     }
 

--- a/ai-gateway/src/middleware/mapper/registry.rs
+++ b/ai-gateway/src/middleware/mapper/registry.rs
@@ -231,6 +231,23 @@ impl EndpointConverterRegistryInner {
         ));
         registry.register_converter(key, converter);
 
+        let key = RegistryKey::new(
+            ApiEndpoint::OpenAI(OpenAI::chat_completions()),
+            ApiEndpoint::OpenAICompatible {
+                provider: InferenceProvider::Named("cohere".into()),
+                openai_endpoint: OpenAI::chat_completions(),
+            },
+        );
+        let converter = TypedEndpointConverter::<
+            endpoints::openai::ChatCompletions,
+            endpoints::openai::OpenAICompatibleChatCompletions,
+            OpenAICompatibleConverter,
+        >::new(OpenAICompatibleConverter::new(
+            InferenceProvider::Named("cohere".into()),
+            model_mapper.clone(),
+        ));
+        registry.register_converter(key, converter);
+
         registry
     }
 

--- a/ai-gateway/src/types/provider.rs
+++ b/ai-gateway/src/types/provider.rs
@@ -139,6 +139,9 @@ impl InferenceProvider {
             "Deepseek" => Ok(InferenceProvider::Named("deepseek".into())),
             "X.AI (Grok)" => Ok(InferenceProvider::Named("xai".into())),
             "Cohere" => Ok(InferenceProvider::Named("cohere".into())),
+            "Hugging Face" | "HuggingFace" => {
+                Ok(InferenceProvider::Named("huggingface".into()))
+            }
             _ => Err(ProviderError::InvalidProviderName(provider_name.into())),
         }
     }

--- a/ai-gateway/src/types/provider.rs
+++ b/ai-gateway/src/types/provider.rs
@@ -138,6 +138,7 @@ impl InferenceProvider {
             "Hyperbolic" => Ok(InferenceProvider::Named("hyperbolic".into())),
             "Deepseek" => Ok(InferenceProvider::Named("deepseek".into())),
             "X.AI (Grok)" => Ok(InferenceProvider::Named("xai".into())),
+            "Cohere" => Ok(InferenceProvider::Named("cohere".into())),
             _ => Err(ProviderError::InvalidProviderName(provider_name.into())),
         }
     }


### PR DESCRIPTION
Production's ingest endpoint (`/api/gateway/ingest`) was accepting **unauthenticated writes from the internet** because `FESTOON_GATEWAY_INGEST_SECRET` was unset — and it was unset because this fork had no way to send a secret: `WebhookConfig` only had `url`.

The API secret is now set, so gateway capture 401s until this ships.

- Adds optional `secret` to `WebhookConfig` → env `AI_GATEWAY__WEBHOOK__SECRET`
- `send_webhook` attaches it as the `x-ingest-secret` header when present
- Secret is `skip_serializing` + redacted through a manual `Debug` impl, so config dumps and traces can't leak it
- `cargo check` clean (one pre-existing unrelated warning)

Maintenance-mode change (security sync), per the Channel 2 posture in the festoon decision record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)